### PR TITLE
Update 07-semantic-kernel.ipynb to include List import

### DIFF
--- a/07-planning-design/code_samples/07-semantic-kernel.ipynb
+++ b/07-planning-design/code_samples/07-semantic-kernel.ipynb
@@ -12,7 +12,7 @@
     "from dotenv import load_dotenv\n",
     "\n",
     "from pydantic import BaseModel, ValidationError, Field\n",
-    "\n",
+    "from typing import List\n",
     "\n",
     "from openai import AsyncOpenAI\n",
     "\n",


### PR DESCRIPTION
The list type in the TravelPlan subtasks needs to be imported. The cell fails to run without it.