### PR TITLE
Docs/shallow clone

### DIFF
--- a/00-course-setup/README.md
+++ b/00-course-setup/README.md
@@ -66,14 +66,16 @@ Then specify which folders you want (example below shows two folders):
 git sparse-checkout set 00-course-setup 01-intro-to-ai-agents
 ```
 
-After cloning and verifying the files, if you only need files and want to free space (no git history), please delete the repository metadata (💀irreversible — you won't be able to git pull later on).
+After cloning and verifying the files, if you only need files and want to free space (no git history), please delete the repository metadata (💀irreversible — you will lose all Git functionality: no commits, pulls, pushes, or history access).
 
 For Linux/macOS:
+
 ```bash
 rm -rf .git
 ```
 
 For Windows:
+
 ```powershell
 Remove-Item -Recurse -Force .git
 ```


### PR DESCRIPTION
Fixes #363 

This pull request adds a new section to the `00-course-setup/README.md` to guide users on efficient ways to clone the course repository, especially for workshops or when using GitHub Codespaces. The instructions help reduce download size and disk usage by using shallow and sparse clone techniques.

Repository cloning and workspace setup improvements:

* Added detailed instructions for performing a shallow clone, allowing users to download only the latest commit history for the repository (`git clone --depth 1`).
* Introduced partial (sparse) clone steps to enable downloading only selected folders, minimizing disk usage and bandwidth (`git clone --filter=blob:none --sparse`).
* Provided commands for removing the `.git` folder after cloning to reclaim space, with OS-specific instructions for Linux/macOS and Windows.
* Added guidance for using GitHub Codespaces with shallow/sparse cloning, including tips on managing workspace size and disk usage.
* Included general tips for customizing the clone process and fetching additional history or folders as needed.

Reduces total artifact initially downloaded from 1970 to 10 and from 2.9 Gb to a mere 15 kb  and completing within 4 seconds
<img width="2066" height="1164" alt="image" src="https://github.com/user-attachments/assets/377ef4a0-278f-48af-a037-7295bc7f424c" />

And use can subsequently add folders as you progress with the workshop. Follows the same principle for modern webapps : lazy loading and progressive enhancements.

<img width="2812" height="1452" alt="image" src="https://github.com/user-attachments/assets/159fc369-2038-44f3-a67b-a0bef58ce168" />

