### PR TITLE
Update devcontainer.json to use .NET 10 GA

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "features": {
     "azure-cli": "latest",
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "20"
+      "version": "lts"
     },
     "ghcr.io/devcontainers/features/dotnet:latest": {
       "version": "10.0"


### PR DESCRIPTION
This PR is:

- To update devcontainer.json to use .NET 10 GA
- To update devcontainer.json to use node.js LTS instead of pinning onto 20.x
