### PR TITLE
fix: 01-dotnet-agent-framework.cs compile error with latest libs

### DIFF
--- a/01-intro-to-ai-agents/code_samples/01-dotnet-agent-framework.cs
+++ b/01-intro-to-ai-agents/code_samples/01-dotnet-agent-framework.cs
@@ -1,8 +1,8 @@
 #!/usr/bin/dotnet run
 
-#:package Microsoft.Extensions.AI@10.1.1
-#:package Microsoft.Extensions.AI.OpenAI@10.1.1-preview.1.25612.2
-#:package Microsoft.Agents.AI.OpenAI@1.0.0-preview.251219.1
+#:package Microsoft.Extensions.AI@10.4.1
+#:package Microsoft.Extensions.AI.OpenAI@10.4.1
+#:package Microsoft.Agents.AI.OpenAI@1.1.0
 
 using System.ClientModel;
 using System.ComponentModel;
@@ -69,8 +69,7 @@ var openAIClient = new OpenAIClient(new ApiKeyCredential(github_token), openAIOp
 // The agent can now plan trips using the GetRandomDestination function
 AIAgent agent = openAIClient
     .GetChatClient(github_model_id)
-    .AsIChatClient()
-    .CreateAIAgent(
+    .AsAIAgent(
         instructions: "You are a helpful AI Agent that can help plan vacations for customers at random destinations",
         tools: [AIFunctionFactory.Create(GetRandomDestination)]
     );


### PR DESCRIPTION
I haven't been able to simply copy, paste and run. I'm running those via usual dotnet projects, not via file. I used latest packages (via `dotnet nuget add <package_name>`) from nuget (no previews) and noticed that current API is broken.

Also, proposed model `gpt-5-mini` currently gives an error, but I decided to not change that for this PR as it can be a temporary thing (with github models public availability).

```
Unhandled exception. System.ClientModel.ClientResultException: HTTP 400 (: unavailable_model)

Unavailable model: gpt-5-mini
```

PS. `gpt-4o-mini` works fine.