### PR TITLE
fix: correct "agent-framewrok" typo to "agent-framework" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The code examples in these exercises utilize Microsoft Agent Framework with Azur
 
 This course uses the following AI Agent frameworks and services from Microsoft:
 
-- [Microsoft Agent Framework (MAF)](https://aka.ms/ai-agents-beginners/agent-framewrok)
+- [Microsoft Agent Framework (MAF)](https://aka.ms/ai-agents-beginners/agent-framework)
 - [Azure AI Foundry Agent Service V2](https://aka.ms/ai-agents-beginners/ai-agent-service)
 
 Some code samples also support alternative OpenAI-compatible providers such as [MiniMax](https://platform.minimaxi.com/), which offers large-context models (up to 204K tokens). See the [Course Setup](./00-course-setup/README.md) for configuration details.


### PR DESCRIPTION
## Summary

Fixes a typo in the Microsoft Agent Framework (MAF) link URL in `README.md`.

## Change

| File | Line | Before | After |
|------|------|--------|-------|
| `README.md` | 74 | `agent-framewrok` | `agent-framework` |

## Why it matters

The typo `framewrok` in the short-link URL causes the link to resolve incorrectly, giving learners a broken experience when they try to access the Microsoft Agent Framework documentation.

Closes #525

---
*Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>*