### PR TITLE
fix: remove unused turtle import from MCP server

### DIFF
--- a/11-agentic-protocols/code_samples/mcp-agents/server/server.py
+++ b/11-agentic-protocols/code_samples/mcp-agents/server/server.py
@@ -10,7 +10,7 @@ import argparse
 import asyncio
 import logging
 import re
-from turtle import st
+
 from typing import Optional
 
 import anyio


### PR DESCRIPTION
## Summary
Removes the unused `from turtle import st` import in `11-agentic-protocols/code_samples/mcp-agents/server/server.py`.

This import is clearly accidental (likely IDE autocomplete). The `st` variable is never used anywhere in the file, and the `turtle` module opens a graphics window on import, which would be undesirable for a server process.

## Testing
- Verified `st` is not referenced anywhere in the file
- No behavioral changes — only removes dead code