### PR TITLE
fix: clear notebook outputs containing developer paths and saved errors

### DIFF
--- a/08-multi-agent/code_samples/workflows-agent-framework/python/01.python-agent-framework-workflow-ghmodel-basic.ipynb
+++ b/08-multi-agent/code_samples/workflows-agent-framework/python/01.python-agent-framework-workflow-ghmodel-basic.ipynb
@@ -87,109 +87,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "c0863be7",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: agent-framework-core in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (1.0.0b251007)\n",
-      "Requirement already satisfied: openai<2,>=1.99.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from agent-framework-core) (1.99.9)\n",
-      "Requirement already satisfied: pydantic<3,>=2 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from agent-framework-core) (2.11.9)\n",
-      "Requirement already satisfied: pydantic-settings<3,>=2 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from agent-framework-core) (2.9.1)\n",
-      "Requirement already satisfied: typing-extensions in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from agent-framework-core) (4.13.2)\n",
-      "Requirement already satisfied: opentelemetry-api>=1.24 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from agent-framework-core) (1.37.0)\n",
-      "Requirement already satisfied: opentelemetry-sdk>=1.24 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from agent-framework-core) (1.37.0)\n",
-      "Requirement already satisfied: mcp>=1.13 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from mcp[ws]>=1.13->agent-framework-core) (1.13.1)\n",
-      "Requirement already satisfied: azure-monitor-opentelemetry>=1.7.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from agent-framework-core) (1.8.1)\n",
-      "Requirement already satisfied: azure-monitor-opentelemetry-exporter>=1.0.0b41 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from agent-framework-core) (1.0.0b42)\n",
-      "Requirement already satisfied: opentelemetry-exporter-otlp-proto-grpc>=1.36.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from agent-framework-core) (1.37.0)\n",
-      "Requirement already satisfied: opentelemetry-semantic-conventions-ai>=0.4.13 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from agent-framework-core) (0.4.13)\n",
-      "Requirement already satisfied: aiofiles>=24.1.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from agent-framework-core) (24.1.0)\n",
-      "Requirement already satisfied: azure-identity<2,>=1 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from agent-framework-core) (1.22.0)\n",
-      "Requirement already satisfied: azure-core>=1.31.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-identity<2,>=1->agent-framework-core) (1.34.0)\n",
-      "Requirement already satisfied: cryptography>=2.5 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-identity<2,>=1->agent-framework-core) (44.0.3)\n",
-      "Requirement already satisfied: msal>=1.30.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-identity<2,>=1->agent-framework-core) (1.32.3)\n",
-      "Requirement already satisfied: msal-extensions>=1.2.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-identity<2,>=1->agent-framework-core) (1.3.1)\n",
-      "Requirement already satisfied: anyio<5,>=3.5.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from openai<2,>=1.99.0->agent-framework-core) (4.9.0)\n",
-      "Requirement already satisfied: distro<2,>=1.7.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from openai<2,>=1.99.0->agent-framework-core) (1.9.0)\n",
-      "Requirement already satisfied: httpx<1,>=0.23.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from openai<2,>=1.99.0->agent-framework-core) (0.28.1)\n",
-      "Requirement already satisfied: jiter<1,>=0.4.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from openai<2,>=1.99.0->agent-framework-core) (0.9.0)\n",
-      "Requirement already satisfied: sniffio in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from openai<2,>=1.99.0->agent-framework-core) (1.3.1)\n",
-      "Requirement already satisfied: tqdm>4 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from openai<2,>=1.99.0->agent-framework-core) (4.67.1)\n",
-      "Requirement already satisfied: idna>=2.8 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from anyio<5,>=3.5.0->openai<2,>=1.99.0->agent-framework-core) (3.10)\n",
-      "Requirement already satisfied: certifi in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from httpx<1,>=0.23.0->openai<2,>=1.99.0->agent-framework-core) (2025.4.26)\n",
-      "Requirement already satisfied: httpcore==1.* in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from httpx<1,>=0.23.0->openai<2,>=1.99.0->agent-framework-core) (1.0.9)\n",
-      "Requirement already satisfied: h11>=0.16 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai<2,>=1.99.0->agent-framework-core) (0.16.0)\n",
-      "Requirement already satisfied: annotated-types>=0.6.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from pydantic<3,>=2->agent-framework-core) (0.7.0)\n",
-      "Requirement already satisfied: pydantic-core==2.33.2 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from pydantic<3,>=2->agent-framework-core) (2.33.2)\n",
-      "Requirement already satisfied: typing-inspection>=0.4.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from pydantic<3,>=2->agent-framework-core) (0.4.0)\n",
-      "Requirement already satisfied: python-dotenv>=0.21.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from pydantic-settings<3,>=2->agent-framework-core) (1.0.1)\n",
-      "Requirement already satisfied: requests>=2.21.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-core>=1.31.0->azure-identity<2,>=1->agent-framework-core) (2.32.3)\n",
-      "Requirement already satisfied: six>=1.11.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-core>=1.31.0->azure-identity<2,>=1->agent-framework-core) (1.17.0)\n",
-      "Requirement already satisfied: azure-core-tracing-opentelemetry~=1.0.0b11 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (1.0.0b12)\n",
-      "Requirement already satisfied: opentelemetry-instrumentation-django~=0.57b0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (0.58b0)\n",
-      "Requirement already satisfied: opentelemetry-instrumentation-fastapi~=0.57b0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (0.58b0)\n",
-      "Requirement already satisfied: opentelemetry-instrumentation-flask~=0.57b0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (0.58b0)\n",
-      "Requirement already satisfied: opentelemetry-instrumentation-psycopg2~=0.57b0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (0.58b0)\n",
-      "Requirement already satisfied: opentelemetry-instrumentation-requests~=0.57b0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (0.58b0)\n",
-      "Requirement already satisfied: opentelemetry-instrumentation-urllib~=0.57b0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (0.58b0)\n",
-      "Requirement already satisfied: opentelemetry-instrumentation-urllib3~=0.57b0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (0.58b0)\n",
-      "Requirement already satisfied: opentelemetry-resource-detector-azure~=0.1.5 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (0.1.5)\n",
-      "Requirement already satisfied: fixedint==0.1.6 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-monitor-opentelemetry-exporter>=1.0.0b41->agent-framework-core) (0.1.6)\n",
-      "Requirement already satisfied: msrest>=0.6.10 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-monitor-opentelemetry-exporter>=1.0.0b41->agent-framework-core) (0.7.1)\n",
-      "Requirement already satisfied: psutil<8,>=5.9 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from azure-monitor-opentelemetry-exporter>=1.0.0b41->agent-framework-core) (7.0.0)\n",
-      "Requirement already satisfied: importlib-metadata<8.8.0,>=6.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from opentelemetry-api>=1.24->agent-framework-core) (8.6.1)\n",
-      "Requirement already satisfied: zipp>=3.20 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from importlib-metadata<8.8.0,>=6.0->opentelemetry-api>=1.24->agent-framework-core) (3.21.0)\n",
-      "Requirement already satisfied: opentelemetry-instrumentation-wsgi==0.58b0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from opentelemetry-instrumentation-django~=0.57b0->azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (0.58b0)\n",
-      "Requirement already satisfied: opentelemetry-instrumentation==0.58b0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from opentelemetry-instrumentation-django~=0.57b0->azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (0.58b0)\n",
-      "Requirement already satisfied: opentelemetry-semantic-conventions==0.58b0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from opentelemetry-instrumentation-django~=0.57b0->azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (0.58b0)\n",
-      "Requirement already satisfied: opentelemetry-util-http==0.58b0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from opentelemetry-instrumentation-django~=0.57b0->azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (0.58b0)\n",
-      "Requirement already satisfied: packaging>=18.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from opentelemetry-instrumentation==0.58b0->opentelemetry-instrumentation-django~=0.57b0->azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (24.2)\n",
-      "Requirement already satisfied: wrapt<2.0.0,>=1.0.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from opentelemetry-instrumentation==0.58b0->opentelemetry-instrumentation-django~=0.57b0->azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (1.17.2)\n",
-      "Requirement already satisfied: opentelemetry-instrumentation-asgi==0.58b0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from opentelemetry-instrumentation-fastapi~=0.57b0->azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (0.58b0)\n",
-      "Requirement already satisfied: asgiref~=3.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from opentelemetry-instrumentation-asgi==0.58b0->opentelemetry-instrumentation-fastapi~=0.57b0->azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (3.8.1)\n",
-      "Requirement already satisfied: opentelemetry-instrumentation-dbapi==0.58b0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from opentelemetry-instrumentation-psycopg2~=0.57b0->azure-monitor-opentelemetry>=1.7.0->agent-framework-core) (0.58b0)\n",
-      "Requirement already satisfied: cffi>=1.12 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from cryptography>=2.5->azure-identity<2,>=1->agent-framework-core) (1.17.1)\n",
-      "Requirement already satisfied: pycparser in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from cffi>=1.12->cryptography>=2.5->azure-identity<2,>=1->agent-framework-core) (2.22)\n",
-      "Requirement already satisfied: httpx-sse>=0.4 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from mcp>=1.13->mcp[ws]>=1.13->agent-framework-core) (0.4.0)\n",
-      "Requirement already satisfied: jsonschema>=4.20.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from mcp>=1.13->mcp[ws]>=1.13->agent-framework-core) (4.23.0)\n",
-      "Requirement already satisfied: python-multipart>=0.0.9 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from mcp>=1.13->mcp[ws]>=1.13->agent-framework-core) (0.0.18)\n",
-      "Requirement already satisfied: sse-starlette>=1.6.1 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from mcp>=1.13->mcp[ws]>=1.13->agent-framework-core) (2.3.4)\n",
-      "Requirement already satisfied: starlette>=0.27 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from mcp>=1.13->mcp[ws]>=1.13->agent-framework-core) (0.41.3)\n",
-      "Requirement already satisfied: uvicorn>=0.31.1 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from mcp>=1.13->mcp[ws]>=1.13->agent-framework-core) (0.34.2)\n",
-      "Requirement already satisfied: attrs>=22.2.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from jsonschema>=4.20.0->mcp>=1.13->mcp[ws]>=1.13->agent-framework-core) (25.3.0)\n",
-      "Requirement already satisfied: jsonschema-specifications>=2023.03.6 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from jsonschema>=4.20.0->mcp>=1.13->mcp[ws]>=1.13->agent-framework-core) (2025.4.1)\n",
-      "Requirement already satisfied: referencing>=0.28.4 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from jsonschema>=4.20.0->mcp>=1.13->mcp[ws]>=1.13->agent-framework-core) (0.36.2)\n",
-      "Requirement already satisfied: rpds-py>=0.7.1 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from jsonschema>=4.20.0->mcp>=1.13->mcp[ws]>=1.13->agent-framework-core) (0.24.0)\n",
-      "Requirement already satisfied: websockets>=15.0.1 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from mcp[ws]>=1.13->agent-framework-core) (15.0.1)\n",
-      "Requirement already satisfied: PyJWT<3,>=1.0.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from PyJWT[crypto]<3,>=1.0.0->msal>=1.30.0->azure-identity<2,>=1->agent-framework-core) (2.10.1)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from requests>=2.21.0->azure-core>=1.31.0->azure-identity<2,>=1->agent-framework-core) (3.4.2)\n",
-      "Requirement already satisfied: urllib3<3,>=1.21.1 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from requests>=2.21.0->azure-core>=1.31.0->azure-identity<2,>=1->agent-framework-core) (2.4.0)\n",
-      "Requirement already satisfied: isodate>=0.6.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from msrest>=0.6.10->azure-monitor-opentelemetry-exporter>=1.0.0b41->agent-framework-core) (0.7.2)\n",
-      "Requirement already satisfied: requests-oauthlib>=0.5.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from msrest>=0.6.10->azure-monitor-opentelemetry-exporter>=1.0.0b41->agent-framework-core) (2.0.0)\n",
-      "Requirement already satisfied: googleapis-common-protos~=1.57 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from opentelemetry-exporter-otlp-proto-grpc>=1.36.0->agent-framework-core) (1.70.0)\n",
-      "Requirement already satisfied: grpcio<2.0.0,>=1.63.2 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from opentelemetry-exporter-otlp-proto-grpc>=1.36.0->agent-framework-core) (1.71.0)\n",
-      "Requirement already satisfied: opentelemetry-exporter-otlp-proto-common==1.37.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from opentelemetry-exporter-otlp-proto-grpc>=1.36.0->agent-framework-core) (1.37.0)\n",
-      "Requirement already satisfied: opentelemetry-proto==1.37.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from opentelemetry-exporter-otlp-proto-grpc>=1.36.0->agent-framework-core) (1.37.0)\n",
-      "Requirement already satisfied: protobuf<7.0,>=5.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from opentelemetry-proto==1.37.0->opentelemetry-exporter-otlp-proto-grpc>=1.36.0->agent-framework-core) (5.29.5)\n",
-      "Requirement already satisfied: oauthlib>=3.0.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from requests-oauthlib>=0.5.0->msrest>=0.6.10->azure-monitor-opentelemetry-exporter>=1.0.0b41->agent-framework-core) (3.2.2)\n",
-      "Requirement already satisfied: click>=7.0 in /Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages (from uvicorn>=0.31.1->mcp>=1.13->mcp[ws]>=1.13->agent-framework-core) (8.1.8)\n",
-      "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.1.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.2\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "! pip install agent-framework-core -U"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "580e76d9",
    "metadata": {},
    "outputs": [],
@@ -203,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "5fe71939",
    "metadata": {},
    "outputs": [],
@@ -217,21 +125,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "cf183974",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# 🔧 Initialize Environment Configuration\n",
     "# Load GitHub Models API credentials from .env file\n",
@@ -240,23 +137,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "7a679634",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ServiceInitializationError",
-     "evalue": "OpenAI model ID is required. Set via 'model_id' parameter or 'OPENAI_CHAT_MODEL_ID' environment variable.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mServiceInitializationError\u001b[39m                Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[6]\u001b[39m\u001b[32m, line 3\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# 🔗 Initialize GitHub Models Chat Client for Workflow Operations\u001b[39;00m\n\u001b[32m      2\u001b[39m \u001b[38;5;66;03m# Create the AI client that will power agents within our workflow\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m3\u001b[39m chat_client = \u001b[43mOpenAIChatClient\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m      4\u001b[39m \u001b[43m    \u001b[49m\u001b[43mbase_url\u001b[49m\u001b[43m=\u001b[49m\u001b[43mos\u001b[49m\u001b[43m.\u001b[49m\u001b[43menviron\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mGITHUB_ENDPOINT\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m    \u001b[49m\u001b[38;5;66;43;03m# 🌐 GitHub Models API endpoint\u001b[39;49;00m\n\u001b[32m      5\u001b[39m \u001b[43m    \u001b[49m\u001b[43mapi_key\u001b[49m\u001b[43m=\u001b[49m\u001b[43mos\u001b[49m\u001b[43m.\u001b[49m\u001b[43menviron\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mGITHUB_TOKEN\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m        \u001b[49m\u001b[38;5;66;43;03m# 🔑 Authentication token\u001b[39;49;00m\n\u001b[32m      6\u001b[39m \u001b[43m    \u001b[49m\u001b[43mmodel_id\u001b[49m\u001b[43m=\u001b[49m\u001b[43mos\u001b[49m\u001b[43m.\u001b[49m\u001b[43menviron\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mGITHUB_MODEL_ID\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;66;43;03m# 🎯 Selected AI model\u001b[39;49;00m\n\u001b[32m      7\u001b[39m \u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/ai-agents-for-beginners/.venv/lib/python3.12/site-packages/agent_framework/openai/_chat_client.py:536\u001b[39m, in \u001b[36mOpenAIChatClient.__init__\u001b[39m\u001b[34m(self, model_id, api_key, org_id, default_headers, async_client, instruction_role, base_url, env_file_path, env_file_encoding)\u001b[39m\n\u001b[32m    532\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m ServiceInitializationError(\n\u001b[32m    533\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mOpenAI API key is required. Set via \u001b[39m\u001b[33m'\u001b[39m\u001b[33mapi_key\u001b[39m\u001b[33m'\u001b[39m\u001b[33m parameter or \u001b[39m\u001b[33m'\u001b[39m\u001b[33mOPENAI_API_KEY\u001b[39m\u001b[33m'\u001b[39m\u001b[33m environment variable.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    534\u001b[39m     )\n\u001b[32m    535\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m openai_settings.chat_model_id:\n\u001b[32m--> \u001b[39m\u001b[32m536\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m ServiceInitializationError(\n\u001b[32m    537\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mOpenAI model ID is required. \u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    538\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mSet via \u001b[39m\u001b[33m'\u001b[39m\u001b[33mmodel_id\u001b[39m\u001b[33m'\u001b[39m\u001b[33m parameter or \u001b[39m\u001b[33m'\u001b[39m\u001b[33mOPENAI_CHAT_MODEL_ID\u001b[39m\u001b[33m'\u001b[39m\u001b[33m environment variable.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    539\u001b[39m     )\n\u001b[32m    541\u001b[39m \u001b[38;5;28msuper\u001b[39m().\u001b[34m__init__\u001b[39m(\n\u001b[32m    542\u001b[39m     model_id=openai_settings.chat_model_id,\n\u001b[32m    543\u001b[39m     api_key=\u001b[38;5;28mself\u001b[39m._get_api_key(openai_settings.api_key),\n\u001b[32m   (...)\u001b[39m\u001b[32m    548\u001b[39m     instruction_role=instruction_role,\n\u001b[32m    549\u001b[39m )\n",
-      "\u001b[31mServiceInitializationError\u001b[39m: OpenAI model ID is required. Set via 'model_id' parameter or 'OPENAI_CHAT_MODEL_ID' environment variable."
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# 🔗 Initialize GitHub Models Chat Client for Workflow Operations\n",
     "# Create the AI client that will power agents within our workflow\n",

--- a/11-agentic-protocols/code_samples/mcp-agents/server/server.py
+++ b/11-agentic-protocols/code_samples/mcp-agents/server/server.py
@@ -10,7 +10,7 @@ import argparse
 import asyncio
 import logging
 import re
-from turtle import st
+
 from typing import Optional
 
 import anyio

--- a/14-microsoft-agent-framework/code-samples/14-handoff.ipynb
+++ b/14-microsoft-agent-framework/code-samples/14-handoff.ipynb
@@ -30,22 +30,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "8360426f",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ImportError",
-     "evalue": "cannot import name 'HandoffBuilder' from 'agent_framework' (/Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages/agent_framework/__init__.py)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mImportError\u001b[39m                               Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 7\u001b[39m\n\u001b[32m      4\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mcollections\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mabc\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m AsyncIterable\n\u001b[32m      5\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mtyping\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m Any, cast\n\u001b[32m----> \u001b[39m\u001b[32m7\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01magent_framework\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m (\n\u001b[32m      8\u001b[39m     ChatMessage,\n\u001b[32m      9\u001b[39m     HandoffBuilder,\n\u001b[32m     10\u001b[39m     HandoffUserInputRequest,\n\u001b[32m     11\u001b[39m     RequestInfoEvent,\n\u001b[32m     12\u001b[39m     WorkflowEvent,\n\u001b[32m     13\u001b[39m     WorkflowOutputEvent,\n\u001b[32m     14\u001b[39m     WorkflowRunState,\n\u001b[32m     15\u001b[39m     WorkflowStatusEvent,\n\u001b[32m     16\u001b[39m )\n\u001b[32m     18\u001b[39m \u001b[38;5;66;03m# GitHub Models or OpenAI client integration\u001b[39;00m\n\u001b[32m     19\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01magent_framework\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mopenai\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m OpenAIChatClient\n",
-      "\u001b[31mImportError\u001b[39m: cannot import name 'HandoffBuilder' from 'agent_framework' (/Users/koreypace/ai-agents-for-beginners/.venv/lib/python3.12/site-packages/agent_framework/__init__.py)"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import asyncio\n",
     "import json\n",
@@ -83,22 +71,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "3c36ef1d",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'BaseModel' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[2]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[38;5;28;01mclass\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mFlightBookingResult\u001b[39;00m(\u001b[43mBaseModel\u001b[49m):\n\u001b[32m      2\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Flight booking confirmation from the booking agent.\"\"\"\u001b[39;00m\n\u001b[32m      4\u001b[39m     destination: \u001b[38;5;28mstr\u001b[39m\n",
-      "\u001b[31mNameError\u001b[39m: name 'BaseModel' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "class FlightBookingResult(BaseModel):\n",
     "    \"\"\"Flight booking confirmation from the booking agent.\"\"\"\n",


### PR DESCRIPTION
## Summary
Clears cell outputs from two notebooks that contained:

1. **Hardcoded developer paths**: `/Users/koreypace/ai-agents-for-beginners/.venv/...` visible in pip install output cells and error tracebacks
2. **Saved runtime errors**: `ImportError` for `HandoffBuilder` and `ServiceInitializationError` in code cell outputs

For a teaching repository, notebooks should have clean outputs so students run them fresh.

## Files Changed
- `14-microsoft-agent-framework/code-samples/14-handoff.ipynb`
- `08-multi-agent/code_samples/workflows-agent-framework/python/01.python-agent-framework-workflow-ghmodel-basic.ipynb`

## Testing
- Only cell outputs cleared — no code changes