### PR TITLE
fix: added tools variable for email in 10-expense_claim-demo.ipyn

### DIFF
--- a/10-ai-agents-production/code_samples/10-expense_claim-demo.ipynb
+++ b/10-ai-agents-production/code_samples/10-expense_claim-demo.ipynb
@@ -231,6 +231,7 @@
     "\n",
     "email_agent = await provider.create_agent(\n",
     "    name=\"EmailAgent\",\n",
+    "    tools=[generate_expense_email],\n",
     "    instructions=(\n",
     "        \"You are an expense claim email generator. Take the travel expense data from the previous agent \"\n",
     "        \"(in 'date|description|amount|category' format separated by semicolons) and use the \"\n",


### PR DESCRIPTION
## What problem does this fix?
The `tools` variable for email was missing in `10-expense_claim-demo.ipynb`, 
which would cause the notebook to fail when running the email-related section.

## What did I do?
Added the missing `tools` variable for email in the notebook.

## Related Issue