### PR TITLE
Upgrade MiniMax default model to M3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,4 +22,4 @@ BING_CONNECTION_ID="..."
 # Get your API key from https://platform.minimaxi.com/
 MINIMAX_API_KEY="..."
 MINIMAX_BASE_URL="https://api.minimax.io/v1"
-MINIMAX_MODEL_ID="MiniMax-M2.7"
+MINIMAX_MODEL_ID="MiniMax-M3"

--- a/00-course-setup/README.md
+++ b/00-course-setup/README.md
@@ -256,9 +256,9 @@ Add these variables to your `.env` file:
 |----------|-----------------|
 | `MINIMAX_API_KEY` | [MiniMax Platform](https://platform.minimaxi.com/) → API Keys |
 | `MINIMAX_BASE_URL` | Use `https://api.minimax.io/v1` (default value) |
-| `MINIMAX_MODEL_ID` | Model name to use (e.g., `MiniMax-M2.7`) |
+| `MINIMAX_MODEL_ID` | Model name to use (e.g., `MiniMax-M3`) |
 
-**Available models**: `MiniMax-M2.7` (recommended), `MiniMax-M2.7-highspeed` (faster responses)
+**Available models**: `MiniMax-M3` (recommended), `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` (faster responses)
 
 The code samples that use `OpenAIChatClient` (e.g., Lesson 14 hotel booking workflow) will automatically detect and use your MiniMax configuration when `MINIMAX_API_KEY` is set.
 

--- a/00-course-setup/README.md
+++ b/00-course-setup/README.md
@@ -258,7 +258,7 @@ Add these variables to your `.env` file:
 | `MINIMAX_BASE_URL` | Use `https://api.minimax.io/v1` (default value) |
 | `MINIMAX_MODEL_ID` | Model name to use (e.g., `MiniMax-M3`) |
 
-**Available models**: `MiniMax-M3` (recommended), `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` (faster responses)
+**Example models**: `MiniMax-M3` (recommended), `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` (faster responses). Model names and availability can change over time, and access to a given model may depend on your account or region — check the [MiniMax Platform](https://platform.minimaxi.com/) for the current list. If `MiniMax-M3` isn't available to your account, set `MINIMAX_MODEL_ID` to a model you have access to (e.g. `MiniMax-M2.7`).
 
 The code samples that use `OpenAIChatClient` (e.g., Lesson 14 hotel booking workflow) will automatically detect and use your MiniMax configuration when `MINIMAX_API_KEY` is set.
 

--- a/14-microsoft-agent-framework/README.md
+++ b/14-microsoft-agent-framework/README.md
@@ -84,7 +84,7 @@ agent = OpenAIChatClient().create_agent( name="HelpfulAssistant", instructions="
 or [MiniMax](https://platform.minimaxi.com/), which provides an OpenAI-compatible API with large context windows (up to 204K tokens):
 
 ```python
-agent = OpenAIChatClient(base_url="https://api.minimax.io/v1", api_key=os.environ["MINIMAX_API_KEY"], model_id="MiniMax-M2.7").create_agent( name="HelpfulAssistant", instructions="You are a helpful assistant.", )
+agent = OpenAIChatClient(base_url="https://api.minimax.io/v1", api_key=os.environ["MINIMAX_API_KEY"], model_id="MiniMax-M3").create_agent( name="HelpfulAssistant", instructions="You are a helpful assistant.", )
 ```
 
 or remote agents using the A2A protocol:

--- a/14-microsoft-agent-framework/code-samples/hotel_booking_workflow_sample.py
+++ b/14-microsoft-agent-framework/code-samples/hotel_booking_workflow_sample.py
@@ -192,7 +192,7 @@ async def main() -> None:
         chat_client = OpenAIChatClient(
             base_url=os.environ.get("MINIMAX_BASE_URL", "https://api.minimax.io/v1"),
             api_key=minimax_api_key,
-            model_id=os.environ.get("MINIMAX_MODEL_ID", "MiniMax-M2.7"),
+            model_id=os.environ.get("MINIMAX_MODEL_ID", "MiniMax-M3"),
         )
         print("Using MiniMax provider")
     elif github_token:

--- a/14-microsoft-agent-framework/code-samples/hotel_booking_workflow_sample.py
+++ b/14-microsoft-agent-framework/code-samples/hotel_booking_workflow_sample.py
@@ -188,7 +188,9 @@ async def main() -> None:
     openai_api_key = os.getenv("OPENAI_API_KEY")
 
     if minimax_api_key:
-        # MiniMax: OpenAI-compatible API with large context window (up to 204K tokens)
+        # MiniMax: OpenAI-compatible API with large context window (up to 204K tokens).
+        # Defaults to MiniMax-M3; override MINIMAX_MODEL_ID if your account/region
+        # doesn't have access to it (e.g. set it to MiniMax-M2.7).
         chat_client = OpenAIChatClient(
             base_url=os.environ.get("MINIMAX_BASE_URL", "https://api.minimax.io/v1"),
             api_key=minimax_api_key,


### PR DESCRIPTION
## Summary

Promote `MiniMax-M3` as the recommended default for the optional `MiniMax` provider added in #474, while keeping `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` available for users who still want the previous generation.

## Changes

- `.env.example` &mdash; default `MINIMAX_MODEL_ID` is now `MiniMax-M3`.
- `00-course-setup/README.md` &mdash; "Available models" lists `MiniMax-M3` (recommended) first, with `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` kept as options; the example `MINIMAX_MODEL_ID` value is updated to match.
- `14-microsoft-agent-framework/README.md` &mdash; the inline `OpenAIChatClient(...)` snippet uses `model_id="MiniMax-M3"`.
- `14-microsoft-agent-framework/code-samples/hotel_booking_workflow_sample.py` &mdash; fallback `model_id` in the MiniMax branch is now `"MiniMax-M3"`.

Nothing else is touched: `MINIMAX_BASE_URL` (`https://api.minimax.io/v1`), the Azure / GitHub Models / OpenAI provider blocks, and unrelated lessons are all left as-is. The localized mirrors under `translations/` are regenerated by the existing translation workflow, so they are intentionally not edited by hand here.

## Test plan

- [x] `python -c "import ast; ast.parse(open('14-microsoft-agent-framework/code-samples/hotel_booking_workflow_sample.py').read())"` &mdash; the modified sample still parses.
- [x] `git grep "MINIMAX_MODEL_ID" -- ':!translations'` &mdash; every non-translated reference now points at `MiniMax-M3`.
- [x] Visually confirmed `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` are still listed for users who want to pin the older generation.