### PR TITLE
fix(lesson-04): replace deprecated AzureAIProjectAgentProvider with FoundryChatClient

### DIFF
--- a/04-tool-use/code_samples/04-python-agent-framework.ipynb
+++ b/04-tool-use/code_samples/04-python-agent-framework.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install agent-framework azure-ai-projects azure-identity -U -q"
+    "! pip install agent-framework azure-ai-projects azure-identity python-dotenv -U -q"
    ]
   },
   {
@@ -43,16 +43,33 @@
    "outputs": [],
    "source": [
     "import logging\n",
-    "logging.getLogger(\"agent_framework.azure\").setLevel(logging.ERROR)\n",
+    "logging.getLogger(\"agent_framework.foundry\").setLevel(logging.ERROR)\n",
     "\n",
     "import os\n",
     "import asyncio\n",
+    "import dotenv\n",
     "from typing import Annotated\n",
     "\n",
     "from pydantic import BaseModel\n",
     "from agent_framework import tool\n",
-    "from agent_framework.azure import AzureAIProjectAgentProvider\n",
-    "from azure.identity import AzureCliCredential"
+    "from agent_framework.foundry import FoundryChatClient\n",
+    "from azure.identity import DefaultAzureCredential\n",
+    "\n",
+    "dotenv.load_dotenv(dotenv.find_dotenv())\n",
+    "\n",
+    "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
+    "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",
+    "\n",
+    "missing = [k for k, v in {\n",
+    "    \"AZURE_AI_PROJECT_ENDPOINT\": endpoint,\n",
+    "    \"AZURE_AI_MODEL_DEPLOYMENT_NAME\": deployment_name\n",
+    "}.items() if not v]\n",
+    "\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variables: {', '.join(missing)}. \"\n",
+    "        \"Please set them as environment variables (e.g., in your .env file or shell environment).\"\n",
+    "    )"
    ]
   },
   {
@@ -63,7 +80,11 @@
    "outputs": [],
    "source": [
     "# Create the Azure AI Foundry provider\n",
-    "provider = AzureAIProjectAgentProvider(credential=AzureCliCredential())"
+    "provider = FoundryChatClient(\n",
+    "    project_endpoint=endpoint,\n",
+    "    model=deployment_name,\n",
+    "    credential=DefaultAzureCredential()\n",
+    ")"
    ]
   },
   {
@@ -146,7 +167,7 @@
    "source": [
     "travel_tools = [get_destinations, check_availability, get_flight_info]\n",
     "\n",
-    "agent = await provider.create_agent(\n",
+    "agent = provider.as_agent(\n",
     "    name=\"TravelToolAgent\",\n",
     "    instructions=\"You are a travel agent. Use the available tools to answer questions about destinations, availability, and flights.\",\n",
     "    tools=travel_tools,\n",
@@ -186,7 +207,7 @@
     "    recommendations: list[BookingRecommendation]\n",
     "\n",
     "\n",
-    "structured_agent = await provider.create_agent(\n",
+    "structured_agent = provider.as_agent(\n",
     "    name=\"StructuredTravelAgent\",\n",
     "    instructions=(\n",
     "        \"You are a travel agent. Use the available tools to find destinations, \"\n",

--- a/04-tool-use/code_samples/04-python-agent-framework.ipynb
+++ b/04-tool-use/code_samples/04-python-agent-framework.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install agent-framework azure-ai-projects azure-identity python-dotenv -U -q"
+    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv -U -q"
    ]
   },
   {
@@ -79,8 +79,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create the Azure AI Foundry provider\n",
-    "provider = FoundryChatClient(\n",
+    "# Create the Azure AI Foundry client\n",
+    "client = FoundryChatClient(\n",
     "    project_endpoint=endpoint,\n",
     "    model=deployment_name,\n",
     "    credential=DefaultAzureCredential()\n",
@@ -167,7 +167,7 @@
    "source": [
     "travel_tools = [get_destinations, check_availability, get_flight_info]\n",
     "\n",
-    "agent = provider.as_agent(\n",
+    "agent = client.as_agent(\n",
     "    name=\"TravelToolAgent\",\n",
     "    instructions=\"You are a travel agent. Use the available tools to answer questions about destinations, availability, and flights.\",\n",
     "    tools=travel_tools,\n",
@@ -207,7 +207,7 @@
     "    recommendations: list[BookingRecommendation]\n",
     "\n",
     "\n",
-    "structured_agent = provider.as_agent(\n",
+    "structured_agent = client.as_agent(\n",
     "    name=\"StructuredTravelAgent\",\n",
     "    instructions=(\n",
     "        \"You are a travel agent. Use the available tools to find destinations, \"\n",

--- a/translations/es/04-tool-use/code_samples/04-python-agent-framework.ipynb
+++ b/translations/es/04-tool-use/code_samples/04-python-agent-framework.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install agent-framework azure-ai-projects azure-identity python-dotenv -U -q"
+    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv -U -q"
    ]
   },
   {
@@ -79,8 +79,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create the Azure AI Foundry provider\n",
-    "provider = FoundryChatClient(\n",
+    "# Create the Azure AI Foundry client\n",
+    "client = FoundryChatClient(\n",
     "    project_endpoint=endpoint,\n",
     "    model=deployment_name,\n",
     "    credential=DefaultAzureCredential()\n",
@@ -167,7 +167,7 @@
    "source": [
     "travel_tools = [get_destinations, check_availability, get_flight_info]\n",
     "\n",
-    "agent = provider.as_agent(\n",
+    "agent = client.as_agent(\n",
     "    name=\"TravelToolAgent\",\n",
     "    instructions=\"You are a travel agent. Use the available tools to answer questions about destinations, availability, and flights.\",\n",
     "    tools=travel_tools,\n",
@@ -207,7 +207,7 @@
     "    recommendations: list[BookingRecommendation]\n",
     "\n",
     "\n",
-    "structured_agent = provider.as_agent(\n",
+    "structured_agent = client.as_agent(\n",
     "    name=\"StructuredTravelAgent\",\n",
     "    instructions=(\n",
     "        \"You are a travel agent. Use the available tools to find destinations, \"\n",

--- a/translations/es/04-tool-use/code_samples/04-python-agent-framework.ipynb
+++ b/translations/es/04-tool-use/code_samples/04-python-agent-framework.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install agent-framework azure-ai-projects azure-identity -U -q"
+    "! pip install agent-framework azure-ai-projects azure-identity python-dotenv -U -q"
    ]
   },
   {
@@ -43,16 +43,33 @@
    "outputs": [],
    "source": [
     "import logging\n",
-    "logging.getLogger(\"agent_framework.azure\").setLevel(logging.ERROR)\n",
+    "logging.getLogger(\"agent_framework.foundry\").setLevel(logging.ERROR)\n",
     "\n",
     "import os\n",
     "import asyncio\n",
+    "import dotenv\n",
     "from typing import Annotated\n",
     "\n",
     "from pydantic import BaseModel\n",
     "from agent_framework import tool\n",
-    "from agent_framework.azure import AzureAIProjectAgentProvider\n",
-    "from azure.identity import AzureCliCredential"
+    "from agent_framework.foundry import FoundryChatClient\n",
+    "from azure.identity import DefaultAzureCredential\n",
+    "\n",
+    "dotenv.load_dotenv(dotenv.find_dotenv())\n",
+    "\n",
+    "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
+    "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",
+    "\n",
+    "missing = [k for k, v in {\n",
+    "    \"AZURE_AI_PROJECT_ENDPOINT\": endpoint,\n",
+    "    \"AZURE_AI_MODEL_DEPLOYMENT_NAME\": deployment_name\n",
+    "}.items() if not v]\n",
+    "\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variables: {', '.join(missing)}. \"\n",
+    "        \"Please set them as environment variables (e.g., in your .env file or shell environment).\"\n",
+    "    )"
    ]
   },
   {
@@ -63,7 +80,11 @@
    "outputs": [],
    "source": [
     "# Create the Azure AI Foundry provider\n",
-    "provider = AzureAIProjectAgentProvider(credential=AzureCliCredential())"
+    "provider = FoundryChatClient(\n",
+    "    project_endpoint=endpoint,\n",
+    "    model=deployment_name,\n",
+    "    credential=DefaultAzureCredential()\n",
+    ")"
    ]
   },
   {
@@ -146,7 +167,7 @@
    "source": [
     "travel_tools = [get_destinations, check_availability, get_flight_info]\n",
     "\n",
-    "agent = await provider.create_agent(\n",
+    "agent = provider.as_agent(\n",
     "    name=\"TravelToolAgent\",\n",
     "    instructions=\"You are a travel agent. Use the available tools to answer questions about destinations, availability, and flights.\",\n",
     "    tools=travel_tools,\n",
@@ -186,7 +207,7 @@
     "    recommendations: list[BookingRecommendation]\n",
     "\n",
     "\n",
-    "structured_agent = await provider.create_agent(\n",
+    "structured_agent = provider.as_agent(\n",
     "    name=\"StructuredTravelAgent\",\n",
     "    instructions=(\n",
     "        \"You are a travel agent. Use the available tools to find destinations, \"\n",
@@ -265,7 +286,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n\n<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n**Aviso legal**:  \nEste documento ha sido traducido utilizando el servicio de traducción automática [Co-op Translator](https://github.com/Azure/co-op-translator). Aunque nos esforzamos por la precisión, tenga en cuenta que las traducciones automáticas pueden contener errores o inexactitudes. El documento original en su idioma nativo debe considerarse la fuente autorizada. Para información crítica, se recomienda la traducción profesional realizada por humanos. No nos hacemos responsables de cualquier malentendido o interpretación errónea que pueda surgir del uso de esta traducción.\n<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
+    "---\n",
+    "\n",
+    "<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n",
+    "**Aviso legal**:  \n",
+    "Este documento ha sido traducido utilizando el servicio de traducción automática [Co-op Translator](https://github.com/Azure/co-op-translator). Aunque nos esforzamos por la precisión, tenga en cuenta que las traducciones automáticas pueden contener errores o inexactitudes. El documento original en su idioma nativo debe considerarse la fuente autorizada. Para información crítica, se recomienda la traducción profesional realizada por humanos. No nos hacemos responsables de cualquier malentendido o interpretación errónea que pueda surgir del uso de esta traducción.\n",
+    "<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
    ]
   }
  ],


### PR DESCRIPTION
## Description
Updates lesson 04 notebook to use the current Microsoft Agent Framework API. `AzureAIProjectAgentProvider` was removed in `agent-framework` v1.8.x and is no longer available under `agent_framework.azure`.

## Problem
Running the notebook fails immediately with:
```python
ImportError: cannot import name 'AzureAIProjectAgentProvider' from 'agent_framework.azure'
```

## Root Cause
The `agent-framework` library underwent a breaking change where Foundry-related clients were moved from `agent_framework.azure` to `agent_framework.foundry`.

Reference: https://learn.microsoft.com/en-us/agent-framework/support/upgrade/python-2026-significant-changes

## Changes
| Before | After |
|--------|-------|
| `from agent_framework.azure import AzureAIProjectAgentProvider` | `from agent_framework.foundry import FoundryChatClient` |
| `AzureAIProjectAgentProvider(credential=AzureCliCredential())` | `FoundryChatClient(project_endpoint=..., model=..., credential=DefaultAzureCredential())` |
| `provider.create_agent(name=..., instructions=..., tools=...)` | `provider.as_agent(name=..., instructions=..., tools=...)` |

- Replaced `AzureCliCredential` with `DefaultAzureCredential` for better portability
- Added `python-dotenv` to install cell
- Added environment variable validation with actionable error message
- Applied all fixes to both English and Spanish (`translations/es`) notebooks

## Testing
Verified working in GitHub Codespaces with:
- agent-framework: 1.8.1
- Python: 3.12.13
- azure-identity: 1.25.3
- azure-ai-projects: 2.2.0

## Related
- Closes: 
   - #579 
- Related to: 
   - #572 
   - #575 
   - #577 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor