### PR TITLE
fix(lesson-05): replace deprecated AzureAIProjectAgentProvider with FoundryChatClient

### DIFF
--- a/05-agentic-rag/code_samples/05-python-agent-framework.ipynb
+++ b/05-agentic-rag/code_samples/05-python-agent-framework.ipynb
@@ -53,7 +53,7 @@
     "from agent_framework.foundry import FoundryChatClient\n",
     "from azure.identity import DefaultAzureCredential\n",
     "\n",
-    "dotenv.load_dotenv(dotenv.find_dotenv())\n",
+    "dotenv.load_dotenv()\n",
     "\n",
     "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
     "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",

--- a/05-agentic-rag/code_samples/05-python-agent-framework.ipynb
+++ b/05-agentic-rag/code_samples/05-python-agent-framework.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install agent-framework azure-ai-projects azure-identity -q"
+    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv -q"
    ]
   },
   {
@@ -42,15 +42,32 @@
    "outputs": [],
    "source": [
     "import logging\n",
-    "logging.getLogger(\"agent_framework.azure\").setLevel(logging.ERROR)\n",
+    "logging.getLogger(\"agent_framework.foundry\").setLevel(logging.ERROR)\n",
     "\n",
     "import os\n",
     "import asyncio\n",
+    "import dotenv\n",
     "from typing import Annotated\n",
     "\n",
     "from agent_framework import tool\n",
-    "from agent_framework.azure import AzureAIProjectAgentProvider\n",
-    "from azure.identity import AzureCliCredential"
+    "from agent_framework.foundry import FoundryChatClient\n",
+    "from azure.identity import DefaultAzureCredential\n",
+    "\n",
+    "dotenv.load_dotenv(dotenv.find_dotenv())\n",
+    "\n",
+    "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
+    "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",
+    "\n",
+    "missing = [k for k, v in {\n",
+    "    \"AZURE_AI_PROJECT_ENDPOINT\": endpoint,\n",
+    "    \"AZURE_AI_MODEL_DEPLOYMENT_NAME\": deployment_name\n",
+    "}.items() if not v]\n",
+    "\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variables: {', '.join(missing)}. \"\n",
+    "        \"Please set them as environment variables (e.g., in your .env file or shell environment).\"\n",
+    "    )"
    ]
   },
   {
@@ -60,8 +77,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "provider = AzureAIProjectAgentProvider(credential=AzureCliCredential())"
+    "# Create the Azure AI Foundry client\n",
+    "client = FoundryChatClient(\n",
+    "    project_endpoint=endpoint,\n",
+    "    model=deployment_name,\n",
+    "    credential=DefaultAzureCredential()\n",
+    ")"
    ]
   },
   {
@@ -144,7 +165,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent = await provider.create_agent(\n",
+    "agent = client.as_agent(\n",
     "    tools=[search_travel_knowledge],\n",
     "    name=\"TravelRAGAgent\",\n",
     "    instructions=\"\"\"You are a knowledgeable travel advisor. Before answering questions about destinations:\n",
@@ -182,7 +203,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "checker_agent = await provider.create_agent(\n",
+    "checker_agent = client.as_agent(\n",
     "    tools=[search_travel_knowledge],\n",
     "    name=\"TravelRAGCheckerAgent\",\n",
     "    instructions=\"\"\"You are a meticulous travel advisor who double-checks recommendations.\n",
@@ -233,7 +254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/translations/es/05-agentic-rag/code_samples/05-python-agent-framework.ipynb
+++ b/translations/es/05-agentic-rag/code_samples/05-python-agent-framework.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install agent-framework azure-ai-projects azure-identity -q"
+    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv -q"
    ]
   },
   {
@@ -42,15 +42,32 @@
    "outputs": [],
    "source": [
     "import logging\n",
-    "logging.getLogger(\"agent_framework.azure\").setLevel(logging.ERROR)\n",
+    "logging.getLogger(\"agent_framework.foundry\").setLevel(logging.ERROR)\n",
     "\n",
     "import os\n",
     "import asyncio\n",
+    "import dotenv\n",
     "from typing import Annotated\n",
     "\n",
     "from agent_framework import tool\n",
-    "from agent_framework.azure import AzureAIProjectAgentProvider\n",
-    "from azure.identity import AzureCliCredential"
+    "from agent_framework.foundry import FoundryChatClient\n",
+    "from azure.identity import DefaultAzureCredential\n",
+    "\n",
+    "dotenv.load_dotenv(dotenv.find_dotenv())\n",
+    "\n",
+    "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
+    "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",
+    "\n",
+    "missing = [k for k, v in {\n",
+    "    \"AZURE_AI_PROJECT_ENDPOINT\": endpoint,\n",
+    "    \"AZURE_AI_MODEL_DEPLOYMENT_NAME\": deployment_name\n",
+    "}.items() if not v]\n",
+    "\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variables: {', '.join(missing)}. \"\n",
+    "        \"Please set them as environment variables (e.g., in your .env file or shell environment).\"\n",
+    "    )"
    ]
   },
   {
@@ -61,7 +78,12 @@
    "outputs": [],
    "source": [
     "\n",
-    "provider = AzureAIProjectAgentProvider(credential=AzureCliCredential())"
+    "# Create the Azure AI Foundry client\n",
+    "client = FoundryChatClient(\n",
+    "    project_endpoint=endpoint,\n",
+    "    model=deployment_name,\n",
+    "    credential=DefaultAzureCredential()\n",
+    ")"
    ]
   },
   {
@@ -144,7 +166,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent = await provider.create_agent(\n",
+    "agent = client.as_agent(\n",
     "    tools=[search_travel_knowledge],\n",
     "    name=\"TravelRAGAgent\",\n",
     "    instructions=\"\"\"You are a knowledgeable travel advisor. Before answering questions about destinations:\n",
@@ -182,7 +204,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "checker_agent = await provider.create_agent(\n",
+    "checker_agent = client.as_agent(\n",
     "    tools=[search_travel_knowledge],\n",
     "    name=\"TravelRAGCheckerAgent\",\n",
     "    instructions=\"\"\"You are a meticulous travel advisor who double-checks recommendations.\n",
@@ -220,7 +242,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n\n<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n**Aviso Legal**:\nEste documento ha sido traducido utilizando el servicio de traducción automática [Co-op Translator](https://github.com/Azure/co-op-translator). Aunque nos esforzamos por la precisión, tenga en cuenta que las traducciones automáticas pueden contener errores o inexactitudes. El documento original en su idioma nativo debe considerarse la fuente autorizada. Para información crítica, se recomienda una traducción profesional realizada por humanos. No nos hacemos responsables de malentendidos o interpretaciones erróneas que puedan derivarse del uso de esta traducción.\n<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
+    "---\n",
+    "\n",
+    "<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n",
+    "**Aviso Legal**:\n",
+    "Este documento ha sido traducido utilizando el servicio de traducción automática [Co-op Translator](https://github.com/Azure/co-op-translator). Aunque nos esforzamos por la precisión, tenga en cuenta que las traducciones automáticas pueden contener errores o inexactitudes. El documento original en su idioma nativo debe considerarse la fuente autorizada. Para información crítica, se recomienda una traducción profesional realizada por humanos. No nos hacemos responsables de malentendidos o interpretaciones erróneas que puedan derivarse del uso de esta traducción.\n",
+    "<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
    ]
   }
  ],
@@ -240,7 +267,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/translations/es/05-agentic-rag/code_samples/05-python-agent-framework.ipynb
+++ b/translations/es/05-agentic-rag/code_samples/05-python-agent-framework.ipynb
@@ -53,7 +53,7 @@
     "from agent_framework.foundry import FoundryChatClient\n",
     "from azure.identity import DefaultAzureCredential\n",
     "\n",
-    "dotenv.load_dotenv(dotenv.find_dotenv())\n",
+    "dotenv.load_dotenv()\n",
     "\n",
     "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
     "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",


### PR DESCRIPTION
## Description
Updates lesson 05 notebook to use the current Microsoft Agent Framework API. `AzureAIProjectAgentProvider` was removed in `agent-framework` v1.8.x and is no longer available under `agent_framework.azure`.

## Problem
Running the notebook fails immediately with:
```python
ImportError: cannot import name 'AzureAIProjectAgentProvider' from 'agent_framework.azure'
```

## Root Cause
The `agent-framework` library underwent a breaking change where Foundry-related clients were moved from `agent_framework.azure` to `agent_framework.foundry`.

Reference: https://learn.microsoft.com/en-us/agent-framework/support/upgrade/python-2026-significant-changes

## Changes
| Before | After |
|--------|-------|
| `from agent_framework.azure import AzureAIProjectAgentProvider` | `from agent_framework.foundry import FoundryChatClient` |
| `AzureAIProjectAgentProvider(credential=AzureCliCredential())` | `FoundryChatClient(project_endpoint=..., model=..., credential=DefaultAzureCredential())` |
| `provider.create_agent(name=..., instructions=..., tools=...)` | `client.as_agent(name=..., instructions=..., tools=...)` |

- Renamed `provider` to `client` for clarity (FoundryChatClient)
- Replaced `AzureCliCredential` with `DefaultAzureCredential` for better portability
- Used `%pip install` instead of `! pip install`
- Added `python-dotenv` to install cell
- Added environment variable validation with actionable error message
- Applied all fixes to both English and Spanish (`translations/es`) notebooks

## Testing
Verified working in GitHub Codespaces with:
- agent-framework: 1.8.1
- Python: 3.12.13
- azure-identity: 1.25.3
- azure-ai-projects: 2.2.0

## Related
- Closes: 
   - #581
- Related to: 
   - #572 
   - #575 
   - #577  
   - #579

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor