### PR TITLE
Fix(lesson-01): Resolve compilation errors in 01-dotnet-agent-framework.cs

### DIFF
--- a/01-intro-to-ai-agents/code_samples/01-dotnet-agent-framework.cs
+++ b/01-intro-to-ai-agents/code_samples/01-dotnet-agent-framework.cs
@@ -11,7 +11,6 @@ using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 
 using OpenAI;
-using OpenAI.Chat;
 
 // Tool Function: Random Destination Generator
 // This static method will be available to the agent as a callable tool
@@ -70,6 +69,7 @@ var openAIClient = new OpenAIClient(new ApiKeyCredential(github_token), openAIOp
 // The agent can now plan trips using the GetRandomDestination function
 AIAgent agent = openAIClient
     .GetChatClient(github_model_id)
+    .AsIChatClient()
     .AsAIAgent(
         instructions: "You are a helpful AI Agent that can help plan vacations for customers at random destinations",
         tools: [AIFunctionFactory.Create(GetRandomDestination)]

--- a/01-intro-to-ai-agents/code_samples/01-dotnet-agent-framework.cs
+++ b/01-intro-to-ai-agents/code_samples/01-dotnet-agent-framework.cs
@@ -11,6 +11,7 @@ using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 
 using OpenAI;
+using OpenAI.Chat;
 
 // Tool Function: Random Destination Generator
 // This static method will be available to the agent as a callable tool


### PR DESCRIPTION
### Description
Fixes CS1929 compilation error in 01-dotnet-agent-framework.cs by importing `OpenAI.Chat` namespace

### Root Cause
During the creation of an agent with `AsAIAgent` the code generates:
> error CS1929: 'ChatClient' does not contain a definition for 'AsAIAgent' ...
`GetChatClient(github_model_id) `returns an `ChatClient` (from the OpenAI SDK).

The extension method `.AsAIAgent(...)` is defined for `Microsoft.Extensions.AI.IChatClient`, not for `ChatClient` directly.



### Changes

- `.AsIChatClient()` to the agent pipeline

#### Before
```
AIAgent agent = openAIClient
    .GetChatClient(github_model_id)
    .AsAIAgent(
        instructions: "You are a helpful AI Agent that can help plan vacations for customers at random destinations",
        tools: [AIFunctionFactory.Create(GetRandomDestination)]
    );
```

#### After
```
AIAgent agent = openAIClient
    .GetChatClient(github_model_id)
    .AsIChatClient()
    .AsAIAgent(
        instructions: "You are a helpful AI Agent that can help plan vacations for customers at random destinations",
        tools: [AIFunctionFactory.Create(GetRandomDestination)]
    );
```

### Testing
Verified code compiles without errors on:
 - OS: Windows 11, macOS Tahoe 26.2
 - dotnet: 10.0.301

Closes: #583