### PR TITLE
Fix(lesson 02): Replaced deprecated AgentThread with AgentSession for context management

### DIFF
--- a/02-explore-agentic-frameworks/code_samples/02-dotnet-agent-framework.cs
+++ b/02-explore-agentic-frameworks/code_samples/02-dotnet-agent-framework.cs
@@ -93,23 +93,23 @@ Always prioritize user preferences. If they mention a specific destination like 
 AIAgent agent = openAIClient
     .GetChatClient(github_model_id)
     .AsIChatClient()
-    .CreateAIAgent(
+    .AsAIAgent(
         name: AGENT_NAME,
         instructions: AGENT_INSTRUCTIONS,
         tools: [AIFunctionFactory.Create(GetRandomDestination)]
     );
 
-// Create New Conversation Thread for Context Management
-// Initialize a new conversation thread to maintain context across multiple interactions
-// Threads enable the agent to remember previous exchanges and maintain conversational state
+// Create New Session for Context Management.
+// Initialize a new conversation session to maintain context across multiple interactions
+// Sessions enable the agent to remember previous exchanges and maintain conversational state
 // This is essential for multi-turn conversations and contextual understanding
-AgentThread thread = agent.GetNewThread();
+AgentSession session = await agent.CreateSessionAsync();
 
 // Execute Agent: First Travel Planning Request
 // Run the agent with an initial request that will likely trigger the random destination tool
 // The agent will analyze the request, use the GetRandomDestination tool, and create an itinerary
 // Using the thread parameter maintains conversation context for subsequent interactions
-await foreach (var update in agent.RunStreamingAsync("Plan me a day trip", thread))
+await foreach (var update in agent.RunStreamingAsync("Plan me a day trip", session))
 {
     await Task.Delay(10);
     Console.Write(update);
@@ -121,7 +121,7 @@ Console.WriteLine();
 // Demonstrate contextual conversation by referencing the previous response
 // The agent remembers the previous destination suggestion and will provide an alternative
 // This showcases the power of conversation threads and contextual understanding in .NET agents
-await foreach (var update in agent.RunStreamingAsync("I don't like that destination. Plan me another vacation.", thread))
+await foreach (var update in agent.RunStreamingAsync("I don't like that destination. Plan me another vacation.", session))
 {
     await Task.Delay(10);
     Console.Write(update);

--- a/02-explore-agentic-frameworks/code_samples/02-dotnet-agent-framework.cs
+++ b/02-explore-agentic-frameworks/code_samples/02-dotnet-agent-framework.cs
@@ -108,7 +108,7 @@ AgentSession session = await agent.CreateSessionAsync();
 // Execute Agent: First Travel Planning Request
 // Run the agent with an initial request that will likely trigger the random destination tool
 // The agent will analyze the request, use the GetRandomDestination tool, and create an itinerary
-// Using the thread parameter maintains conversation context for subsequent interactions
+// Using the session parameter maintains conversation context for subsequent interactions
 await foreach (var update in agent.RunStreamingAsync("Plan me a day trip", session))
 {
     await Task.Delay(10);
@@ -120,7 +120,7 @@ Console.WriteLine();
 // Execute Agent: Follow-up Request with Context Awareness
 // Demonstrate contextual conversation by referencing the previous response
 // The agent remembers the previous destination suggestion and will provide an alternative
-// This showcases the power of conversation threads and contextual understanding in .NET agents
+// This showcases the power of conversation sessions and contextual understanding in .NET agents
 await foreach (var update in agent.RunStreamingAsync("I don't like that destination. Plan me another vacation.", session))
 {
     await Task.Delay(10);


### PR DESCRIPTION
### Description
Fixes `CS1061` and `CS0246` compilation errors in 02-dotnet-agent-framework.cs by updating to the correct agent API methods and types.

Addresses: #587

### Root Cause
During the creation of an agent with outdated methods, the code generated:
> error CS1061: 'IChatClient' does not contain a definition for 'CreateAIAgent' ...
> error CS0246: The type or namespace name 'AgentThread' could not be found ...
> error CS1061: 'AIAgent' does not contain a definition for 'GetNewThread' ...

- The extension method `.CreateAIAgent(...)` is not defined for `IChatClient`. The supported method is `.AsAIAgent(...)`.
- `AgentThread` is not part of the current framework; the correct type is `AgentSession`.
- `GetNewThread()` has been replaced by `CreateSessionAsync()` for session management

Reference: [Multi-turn Conversations, C#](https://learn.microsoft.com/en-us/agent-framework/get-started/multi-turn?pivots=programming-language-csharp)

### Changes
- Replaced `.CreateAIAgent(...)` with `.AsAIAgent(...)`
- Replaced `AgentThread` with `AgentSession`
- Replaced `.GetNewThread()` with .`CreateSessionAsync()`
- Updated inline comments to reflect the correct agent/session workflow


### Testing
Verified code compiles and runs without errors on:
- OS: Windows 11, macOS Tahoe 26.2
- .NET SDK: 10.0.301
- Microsoft.Extensions.AI@10.*
- Microsoft.Extensions.AI.OpenAI@10.*-*
- Microsoft.Agents.AI.OpenAI@1.*-*
