### PR TITLE
Fix(lesson 03): Replaced deprecated AgentThread with AgentSession for context management

### DIFF
--- a/03-agentic-design-patterns/code_samples/03-dotnet-agent-framework.cs
+++ b/03-agentic-design-patterns/code_samples/03-dotnet-agent-framework.cs
@@ -118,7 +118,7 @@ What kind of trip would you like me to help you plan today?"
 AIAgent agent = openAIClient
     .GetChatClient(github_model_id)
     .AsIChatClient()
-    .CreateAIAgent(
+    .AsAIAgent(
         name: AGENT_NAME,
         instructions: AGENT_INSTRUCTIONS,
         tools: [
@@ -128,7 +128,7 @@ AIAgent agent = openAIClient
     );
 
 // Create Conversation Thread for Context Management
-AgentThread thread = agent.GetNewThread();
+AgentSession session = await agent.CreateSessionAsync();
 
 // ============================================================================
 // DEMONSTRATION: Start with "Hello" to trigger the greeting (Issue #402 fix)
@@ -137,7 +137,7 @@ Console.WriteLine("=== Demonstrating Agentic Design Principles ===\n");
 Console.WriteLine("User: Hello\n");
 Console.WriteLine("Agent Response:");
 
-await foreach (var update in agent.RunStreamingAsync("Hello", thread))
+await foreach (var update in agent.RunStreamingAsync("Hello", session))
 {
     await Task.Delay(10);
     Console.Write(update);
@@ -152,7 +152,7 @@ Console.WriteLine("---");
 Console.WriteLine("User: I prefer luxury travel and cultural experiences.\n");
 Console.WriteLine("Agent Response:");
 
-await foreach (var update in agent.RunStreamingAsync("I prefer luxury travel and cultural experiences.", thread))
+await foreach (var update in agent.RunStreamingAsync("I prefer luxury travel and cultural experiences.", session))
 {
     await Task.Delay(10);
     Console.Write(update);
@@ -167,7 +167,7 @@ Console.WriteLine("---");
 Console.WriteLine("User: Suggest a destination for me.\n");
 Console.WriteLine("Agent Response:");
 
-await foreach (var update in agent.RunStreamingAsync("Suggest a destination for me.", thread))
+await foreach (var update in agent.RunStreamingAsync("Suggest a destination for me.", session))
 {
     await Task.Delay(10);
     Console.Write(update);

--- a/03-agentic-design-patterns/code_samples/03-dotnet-agent-framework.cs
+++ b/03-agentic-design-patterns/code_samples/03-dotnet-agent-framework.cs
@@ -128,7 +128,7 @@ AIAgent agent = openAIClient
     );
 
 // Create Conversation Session for Context Management
-AgentSession session = await agent.CreateSessionAsync();
+await using var session = await agent.CreateSessionAsync();
 
 // ============================================================================
 // DEMONSTRATION: Start with "Hello" to trigger the greeting (Issue #402 fix)

--- a/03-agentic-design-patterns/code_samples/03-dotnet-agent-framework.cs
+++ b/03-agentic-design-patterns/code_samples/03-dotnet-agent-framework.cs
@@ -127,7 +127,7 @@ AIAgent agent = openAIClient
         ]
     );
 
-// Create Conversation Thread for Context Management
+// Create Conversation Session for Context Management
 AgentSession session = await agent.CreateSessionAsync();
 
 // ============================================================================


### PR DESCRIPTION
### Description
Fixes `CS1061` and `CS0246` compilation errors in `03-dotnet-agent-framework.cs` by updating to the correct agent API methods and types.  

Addresses: #587

---

### Root Cause
During the creation of an agent with outdated methods, the code generated:

```
error CS1061: 'IChatClient' does not contain a definition for 'CreateAIAgent' ...
error CS0246: The type or namespace name 'AgentThread' could not be found ...
error CS1061: 'AIAgent' does not contain a definition for 'GetNewThread' ...
```

- The extension method `.CreateAIAgent(...)` is not defined for `IChatClient`. The supported method is `.AsAIAgent(...)`.  
- `AgentThread` is not part of the current framework; the correct type is `AgentSession`.  
- `GetNewThread()` has been replaced by `CreateSessionAsync()` for session management.  

Reference: [Multi-turn Conversations, C#](https://learn.microsoft.com/en-us/agent-framework/get-started/multi-turn?pivots=programming-language-csharp)

---

### Changes
- Replaced `.CreateAIAgent(...)` with `.AsAIAgent(...)`  
- Replaced `AgentThread` with `AgentSession`  
- Replaced `.GetNewThread()` with `.CreateSessionAsync()`  

---

### Testing
Verified code compiles and runs without errors on:
- OS: Windows 11, macOS Tahoe 26.2  
- .NET SDK: 10.0.301  
- Microsoft.Extensions.AI@10.*  
- Microsoft.Extensions.AI.OpenAI@10.*-*  
- Microsoft.Agents.AI.OpenAI@1.*-*  

