### PR TITLE
Fix(lesson 04): Replaced deprecated AgentThread with AgentSession for context management

### DIFF
--- a/04-tool-use/code_samples/04-dotnet-agent-framework.cs
+++ b/04-tool-use/code_samples/04-dotnet-agent-framework.cs
@@ -224,7 +224,7 @@ Always mention which tools you used so users understand the agent's capabilities
 AIAgent agent = openAIClient
     .GetChatClient(github_model_id)
     .AsIChatClient()
-    .CreateAIAgent(
+    .AsAIAgent(
         name: AGENT_NAME,
         instructions: AGENT_INSTRUCTIONS,
         tools: [
@@ -235,8 +235,9 @@ AIAgent agent = openAIClient
         ]
     );
 
-// Create Conversation Thread
-AgentThread thread = agent.GetNewThread();
+// Create Conversation Session
+AgentSession session = await agent.CreateSessionAsync();
+
 
 // ============================================================================
 // DEMONSTRATION 1: Tool Selection - Agent picks the right tool
@@ -246,7 +247,7 @@ Console.WriteLine("--- Demo 1: Tool Selection ---");
 Console.WriteLine("User: What's the weather like in Tokyo?\n");
 Console.WriteLine("Agent Response:");
 
-await foreach (var update in agent.RunStreamingAsync("What's the weather like in Tokyo?", thread))
+await foreach (var update in agent.RunStreamingAsync("What's the weather like in Tokyo?", session))
 {
     await Task.Delay(10);
     Console.Write(update);
@@ -261,7 +262,7 @@ Console.WriteLine("--- Demo 2: Parameterized Tool with Multiple Parameters ---")
 Console.WriteLine("User: How much would a 5-day luxury trip to Rome cost?\n");
 Console.WriteLine("Agent Response:");
 
-await foreach (var update in agent.RunStreamingAsync("How much would a 5-day luxury trip to Rome cost?", thread))
+await foreach (var update in agent.RunStreamingAsync("How much would a 5-day luxury trip to Rome cost?", session))
 {
     await Task.Delay(10);
     Console.Write(update);
@@ -278,7 +279,7 @@ Console.WriteLine("Agent Response:");
 
 await foreach (var update in agent.RunStreamingAsync(
     "Plan me a complete trip - suggest a destination and give me all the details including weather and costs for a 3-day moderate budget trip.", 
-    thread))
+    session))
 {
     await Task.Delay(10);
     Console.Write(update);


### PR DESCRIPTION
### Description
Fixes `CS1061` and `CS0246` compilation errors in `04-dotnet-agent-framework.cs` by updating to the correct agent API methods and types.  

Addresses: #587 

---

### Root Cause
During the creation of an agent with outdated methods, the code generated:

```
error CS1061: 'IChatClient' does not contain a definition for 'CreateAIAgent' ...
error CS0246: The type or namespace name 'AgentThread' could not be found ...
error CS1061: 'AIAgent' does not contain a definition for 'GetNewThread' ...
```

- The extension method `.CreateAIAgent(...)` is not defined for `IChatClient`. The supported method is `.AsAIAgent(...)`.  
- `AgentThread` is not part of the current framework; the correct type is `AgentSession`.  
- `GetNewThread()` has been replaced by `CreateSessionAsync()` for session management.  

Reference: [Multi-turn Conversations, C#](https://learn.microsoft.com/en-us/agent-framework/get-started/multi-turn?pivots=programming-language-csharp)
---

### Changes
- Replaced `.CreateAIAgent(...)` with `.AsAIAgent(...)`  
- Replaced `AgentThread` with `AgentSession`  
- Replaced `.GetNewThread()` with `.CreateSessionAsync()`  
- Updated inline comments to reflect the correct agent/session workflow  

---

### Testing
Verified code compiles and runs without errors on:
- OS: Windows 11, macOS Tahoe 26.2  
- .NET SDK: 10.0.301  
- Microsoft.Extensions.AI@10.*  
- Microsoft.Extensions.AI.OpenAI@10.*-*  
- Microsoft.Agents.AI.OpenAI@1.*-*  

---

This PR ensures the **lesson‑04 sample** aligns with the current APIs and demonstrates proper **multi-turn conversation handling**.  