### PR TITLE
Fix formatting of Co-op Translator disclaimer in README

### DIFF
--- a/translations/pcm/11-agentic-protocols/README.md
+++ b/translations/pcm/11-agentic-protocols/README.md
@@ -178,5 +178,5 @@ Join the [Microsoft Foundry Discord](https://aka.ms/ai-agents/discord) to meet w
 
 <!-- CO-OP TRANSLATOR DISCLAIMER START -->
 Disclaimer:
-Dis document don translate by AI translation service [Co-op Translator] (https://github.com/Azure/co-op-translator). Even though we dey try make am correct, abeg sabi say automated translations fit get mistakes or no too accurate. The original document for im original language na the correct source wey you suppose follow. If na important matter, make professional human translator do am. We no go responsible for any misunderstanding or wrong interpretation wey fit come from using this translation.
+Dis document don translate by AI translation service [Co-op Translator](https://github.com/Azure/co-op-translator). Even though we dey try make am correct, abeg sabi say automated translations fit get mistakes or no too accurate. The original document for im original language na the correct source wey you suppose follow. If na important matter, make professional human translator do am. We no go responsible for any misunderstanding or wrong interpretation wey fit come from using this translation.
 <!-- CO-OP TRANSLATOR DISCLAIMER END -->


### PR DESCRIPTION
https://github.com/microsoft/ai-agents-for-beginners/blob/main/translations/pcm/11-agentic-protocols/README.md 

<img width="1167" height="210" alt="image" src="https://github.com/user-attachments/assets/923bca0f-1f30-4a1e-a153-c6f7207aac93" />

related https://github.com/Azure/co-op-translator/issues/363
related https://github.com/microsoft/ai-agents-for-beginners/pull/591

#PingMSFTDocs