### PR TITLE
fix(lesson-10): replace deprecated AzureAIProjectAgentProvider with FoundryChatClient

### DIFF
--- a/10-ai-agents-production/code_samples/10-expense_claim-demo.ipynb
+++ b/10-ai-agents-production/code_samples/10-expense_claim-demo.ipynb
@@ -276,9 +276,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> **Note:** This workflow requires a model with a large context window (128K+ tokens) \n",
-    "> due to the base64-encoded receipt image. If you encounter context window errors, \n",
-    "> try using a smaller receipt image or a model with a larger context window."
+    "> **Note:** This workflow currently passes the receipt image as base64 text, which most chat models (including gpt-4o) will not treat as an image.\n",
+    "> It may also exceed the model context window. Prefer running OCR with Azure AI Vision (or another OCR tool) and pass only extracted text, or refactor to send the image as an `image_url` message.\n",
+    "> If you only want to avoid context errors, try a smaller receipt image or a model with a larger context window."
    ]
   },
   {

--- a/10-ai-agents-production/code_samples/10-expense_claim-demo.ipynb
+++ b/10-ai-agents-production/code_samples/10-expense_claim-demo.ipynb
@@ -50,17 +50,34 @@
    "outputs": [],
    "source": [
     "import logging\n",
-    "logging.getLogger(\"agent_framework.azure\").setLevel(logging.ERROR)\n",
+    "logging.getLogger(\"agent_framework.foundry\").setLevel(logging.ERROR)\n",
     "\n",
     "import os\n",
     "import base64\n",
+    "import dotenv\n",
     "from typing import Annotated, List\n",
     "\n",
     "from pydantic import BaseModel, Field\n",
     "\n",
     "from agent_framework import tool, AgentResponseUpdate, WorkflowBuilder\n",
-    "from agent_framework.azure import AzureAIProjectAgentProvider\n",
-    "from azure.identity import AzureCliCredential"
+    "from agent_framework.foundry import FoundryChatClient\n",
+    "from azure.identity import DefaultAzureCredential\n",
+    "\n",
+    "dotenv.load_dotenv()\n",
+    "\n",
+    "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
+    "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",
+    "\n",
+    "missing = [k for k, v in {\n",
+    "    \"AZURE_AI_PROJECT_ENDPOINT\": endpoint,\n",
+    "    \"AZURE_AI_MODEL_DEPLOYMENT_NAME\": deployment_name\n",
+    "}.items() if not v]\n",
+    "\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variables: {', '.join(missing)}. \"\n",
+    "        \"Please set them as environment variables (e.g., in your .env file or shell environment).\"\n",
+    "    )"
    ]
   },
   {
@@ -69,7 +86,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "provider = AzureAIProjectAgentProvider(credential=AzureCliCredential())"
+    "# Create the Azure AI Foundry client\n",
+    "client = FoundryChatClient(\n",
+    "    project_endpoint=endpoint,\n",
+    "    model=deployment_name,\n",
+    "    credential=DefaultAzureCredential()\n",
+    ")"
    ]
   },
   {
@@ -210,7 +232,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ocr_agent = await provider.create_agent(\n",
+    "ocr_agent = client.as_agent(\n",
     "    tools=[load_receipt_image],\n",
     "    name=\"OCRAgent\",\n",
     "    instructions=(\n",
@@ -229,7 +251,7 @@
     "    ),\n",
     ")\n",
     "\n",
-    "email_agent = await provider.create_agent(\n",
+    "email_agent = client.as_agent(\n",
     "    name=\"EmailAgent\",\n",
     "    tools=[generate_expense_email],\n",
     "    instructions=(\n",
@@ -248,6 +270,15 @@
     "## Main function\n",
     "\n",
     "Build the sequential workflow and run it to process the receipt image and generate the expense claim email."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Note:** This workflow requires a model with a large context window (128K+ tokens) \n",
+    "> due to the base64-encoded receipt image. If you encounter context window errors, \n",
+    "> try using a smaller receipt image or a model with a larger context window."
    ]
   },
   {
@@ -285,13 +316,6 @@
     "            last_author = author\n",
     "        print(update.text, end=\"\", flush=True)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -308,9 +332,9 @@
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbformat_exporter": "python",
+   "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/10-ai-agents-production/code_samples/10-python-agent-framework.ipynb
+++ b/10-ai-agents-production/code_samples/10-python-agent-framework.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv -q"
+    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv -U -q"
    ]
   },
   {

--- a/10-ai-agents-production/code_samples/10-python-agent-framework.ipynb
+++ b/10-ai-agents-production/code_samples/10-python-agent-framework.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install agent-framework azure-ai-projects azure-identity -U -q"
+    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv -q"
    ]
   },
   {
@@ -42,16 +42,33 @@
    "outputs": [],
    "source": [
     "import logging\n",
-    "logging.getLogger(\"agent_framework.azure\").setLevel(logging.ERROR)\n",
+    "logging.getLogger(\"agent_framework.foundry\").setLevel(logging.ERROR)\n",
     "\n",
     "import os\n",
     "import asyncio\n",
     "import time\n",
+    "import dotenv\n",
     "from typing import Annotated\n",
     "\n",
     "from agent_framework import tool\n",
-    "from agent_framework.azure import AzureAIProjectAgentProvider\n",
-    "from azure.identity import AzureCliCredential"
+    "from agent_framework.foundry import FoundryChatClient\n",
+    "from azure.identity import DefaultAzureCredential\n",
+    "\n",
+    "dotenv.load_dotenv()\n",
+    "\n",
+    "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
+    "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",
+    "\n",
+    "missing = [k for k, v in {\n",
+    "    \"AZURE_AI_PROJECT_ENDPOINT\": endpoint,\n",
+    "    \"AZURE_AI_MODEL_DEPLOYMENT_NAME\": deployment_name\n",
+    "}.items() if not v]\n",
+    "\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variables: {', '.join(missing)}. \"\n",
+    "        \"Please set them as environment variables (e.g., in your .env file or shell environment).\"\n",
+    "    )"
    ]
   },
   {
@@ -61,8 +78,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create the Azure AI Foundry provider\n",
-    "provider = AzureAIProjectAgentProvider(credential=AzureCliCredential())\n"
+    "# Create the Azure AI Foundry client\n",
+    "client = FoundryChatClient(\n",
+    "    project_endpoint=endpoint,\n",
+    "    model=deployment_name,\n",
+    "    credential=DefaultAzureCredential()\n",
+    ")"
    ]
   },
   {
@@ -127,7 +148,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent = await provider.create_agent(\n",
+    "agent = client.as_agent(\n",
     "    tools=[get_flight_info, get_activity_suggestions],\n",
     "    name=\"TravelAgent\",\n",
     "    instructions=\"You are a helpful travel agent. Use the available tools to help users plan their trips. Provide comprehensive, actionable travel advice.\",\n",
@@ -164,7 +185,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "evaluator = await provider.create_agent(\n",
+    "evaluator = client.as_agent(\n",
     "    name=\"ResponseEvaluator\",\n",
     "    instructions=\"\"\"You evaluate travel agent responses on these criteria:\n",
     "1. Completeness (1-5): Did it cover flights AND activities?\n",
@@ -231,7 +252,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/translations/es/10-ai-agents-production/code_samples/10-expense_claim-demo.ipynb
+++ b/translations/es/10-ai-agents-production/code_samples/10-expense_claim-demo.ipynb
@@ -276,9 +276,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> **Nota:** Este flujo de trabajo requiere un modelo con una ventana de contexto grande (128K+ tokens) \n",
-    "> debido a la imagen del recibo codificada en base64. Si encuentras errores de ventana de contexto, \n",
-    "> intenta usar una imagen de recibo más pequeña o un modelo con una ventana de contexto más grande."
+    "> **Nota:** Este flujo de trabajo actualmente pasa la imagen del recibo como texto base64, que la mayoría de los modelos de chat (incluido gpt-4o) no procesan como imagen.\n",
+    "> Además, puede exceder la ventana de contexto. Se recomienda hacer OCR con Azure AI Vision (u otra herramienta) y enviar solo el texto extraído, o refactorizar para enviar la imagen como un mensaje `image_url`.\n",
+    "> Si solo necesitas evitar errores de contexto, prueba una imagen de recibo más pequeña o un modelo con una ventana de contexto más grande."
    ]
   },
   {

--- a/translations/es/10-ai-agents-production/code_samples/10-expense_claim-demo.ipynb
+++ b/translations/es/10-ai-agents-production/code_samples/10-expense_claim-demo.ipynb
@@ -50,17 +50,34 @@
    "outputs": [],
    "source": [
     "import logging\n",
-    "logging.getLogger(\"agent_framework.azure\").setLevel(logging.ERROR)\n",
+    "logging.getLogger(\"agent_framework.foundry\").setLevel(logging.ERROR)\n",
     "\n",
     "import os\n",
     "import base64\n",
+    "import dotenv\n",
     "from typing import Annotated, List\n",
     "\n",
     "from pydantic import BaseModel, Field\n",
     "\n",
     "from agent_framework import tool, AgentResponseUpdate, WorkflowBuilder\n",
-    "from agent_framework.azure import AzureAIProjectAgentProvider\n",
-    "from azure.identity import AzureCliCredential"
+    "from agent_framework.foundry import FoundryChatClient\n",
+    "from azure.identity import DefaultAzureCredential\n",
+    "\n",
+    "dotenv.load_dotenv()\n",
+    "\n",
+    "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
+    "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",
+    "\n",
+    "missing = [k for k, v in {\n",
+    "    \"AZURE_AI_PROJECT_ENDPOINT\": endpoint,\n",
+    "    \"AZURE_AI_MODEL_DEPLOYMENT_NAME\": deployment_name\n",
+    "}.items() if not v]\n",
+    "\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variables: {', '.join(missing)}. \"\n",
+    "        \"Please set them as environment variables (e.g., in your .env file or shell environment).\"\n",
+    "    )"
    ]
   },
   {
@@ -69,7 +86,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "provider = AzureAIProjectAgentProvider(credential=AzureCliCredential())"
+    "# Create the Azure AI Foundry client\n",
+    "client = FoundryChatClient(\n",
+    "    project_endpoint=endpoint,\n",
+    "    model=deployment_name,\n",
+    "    credential=DefaultAzureCredential()\n",
+    ")"
    ]
   },
   {
@@ -210,7 +232,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ocr_agent = await provider.create_agent(\n",
+    "ocr_agent = client.as_agent(\n",
     "    tools=[load_receipt_image],\n",
     "    name=\"OCRAgent\",\n",
     "    instructions=(\n",
@@ -229,7 +251,7 @@
     "    ),\n",
     ")\n",
     "\n",
-    "email_agent = await provider.create_agent(\n",
+    "email_agent = client.as_agent(\n",
     "    name=\"EmailAgent\",\n",
     "    tools=[generate_expense_email],\n",
     "    instructions=(\n",
@@ -248,6 +270,15 @@
     "## Función principal\n",
     "\n",
     "Construya el flujo de trabajo secuencial y ejecútelo para procesar la imagen del recibo y generar el correo electrónico de reclamo de gastos.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Nota:** Este flujo de trabajo requiere un modelo con una ventana de contexto grande (128K+ tokens) \n",
+    "> debido a la imagen del recibo codificada en base64. Si encuentras errores de ventana de contexto, \n",
+    "> intenta usar una imagen de recibo más pequeña o un modelo con una ventana de contexto más grande."
    ]
   },
   {
@@ -287,17 +318,15 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n\n<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n**Descargo de responsabilidad**:\nEste documento ha sido traducido utilizando el servicio de traducción automática [Co-op Translator](https://github.com/Azure/co-op-translator). Aunque nos esforzamos por la precisión, tenga en cuenta que las traducciones automatizadas pueden contener errores o inexactitudes. El documento original en su idioma nativo debe considerarse la fuente autorizada. Para información crítica, se recomienda una traducción profesional humana. No somos responsables de cualquier malentendido o interpretación errónea que surja del uso de esta traducción.\n<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
+    "---\n",
+    "\n",
+    "<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n",
+    "**Descargo de responsabilidad**:\n",
+    "Este documento ha sido traducido utilizando el servicio de traducción automática [Co-op Translator](https://github.com/Azure/co-op-translator). Aunque nos esforzamos por la precisión, tenga en cuenta que las traducciones automatizadas pueden contener errores o inexactitudes. El documento original en su idioma nativo debe considerarse la fuente autorizada. Para información crítica, se recomienda una traducción profesional humana. No somos responsables de cualquier malentendido o interpretación errónea que surja del uso de esta traducción.\n",
+    "<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
    ]
   }
  ],
@@ -315,9 +344,9 @@
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbformat_exporter": "python",
+   "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/translations/es/10-ai-agents-production/code_samples/10-python-agent-framework.ipynb
+++ b/translations/es/10-ai-agents-production/code_samples/10-python-agent-framework.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install agent-framework azure-ai-projects azure-identity -U -q"
+    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv -q"
    ]
   },
   {
@@ -42,16 +42,33 @@
    "outputs": [],
    "source": [
     "import logging\n",
-    "logging.getLogger(\"agent_framework.azure\").setLevel(logging.ERROR)\n",
+    "logging.getLogger(\"agent_framework.foundry\").setLevel(logging.ERROR)\n",
     "\n",
     "import os\n",
     "import asyncio\n",
     "import time\n",
+    "import dotenv\n",
     "from typing import Annotated\n",
     "\n",
     "from agent_framework import tool\n",
-    "from agent_framework.azure import AzureAIProjectAgentProvider\n",
-    "from azure.identity import AzureCliCredential"
+    "from agent_framework.foundry import FoundryChatClient\n",
+    "from azure.identity import DefaultAzureCredential\n",
+    "\n",
+    "dotenv.load_dotenv()\n",
+    "\n",
+    "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
+    "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",
+    "\n",
+    "missing = [k for k, v in {\n",
+    "    \"AZURE_AI_PROJECT_ENDPOINT\": endpoint,\n",
+    "    \"AZURE_AI_MODEL_DEPLOYMENT_NAME\": deployment_name\n",
+    "}.items() if not v]\n",
+    "\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variables: {', '.join(missing)}. \"\n",
+    "        \"Please set them as environment variables (e.g., in your .env file or shell environment).\"\n",
+    "    )"
    ]
   },
   {
@@ -61,8 +78,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create the Azure AI Foundry provider\n",
-    "provider = AzureAIProjectAgentProvider(credential=AzureCliCredential())\n"
+    "# Create the Azure AI Foundry client\n",
+    "client = FoundryChatClient(\n",
+    "    project_endpoint=endpoint,\n",
+    "    model=deployment_name,\n",
+    "    credential=DefaultAzureCredential()\n",
+    ")"
    ]
   },
   {
@@ -127,7 +148,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent = await provider.create_agent(\n",
+    "agent = client.as_agent(\n",
     "    tools=[get_flight_info, get_activity_suggestions],\n",
     "    name=\"TravelAgent\",\n",
     "    instructions=\"You are a helpful travel agent. Use the available tools to help users plan their trips. Provide comprehensive, actionable travel advice.\",\n",
@@ -164,7 +185,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "evaluator = await provider.create_agent(\n",
+    "evaluator = client.as_agent(\n",
     "    name=\"ResponseEvaluator\",\n",
     "    instructions=\"\"\"You evaluate travel agent responses on these criteria:\n",
     "1. Completeness (1-5): Did it cover flights AND activities?\n",
@@ -218,7 +239,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n\n<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n**Aviso legal**:\nEste documento ha sido traducido utilizando el servicio de traducción por IA [Co-op Translator](https://github.com/Azure/co-op-translator). Aunque nos esforzamos por la precisión, tenga en cuenta que las traducciones automáticas pueden contener errores o inexactitudes. El documento original en su idioma nativo debe considerarse la fuente autorizada. Para información crítica, se recomienda una traducción profesional realizada por humanos. No nos hacemos responsables de ningún malentendido o interpretación errónea derivada del uso de esta traducción.\n<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
+    "---\n",
+    "\n",
+    "<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n",
+    "**Aviso legal**:\n",
+    "Este documento ha sido traducido utilizando el servicio de traducción por IA [Co-op Translator](https://github.com/Azure/co-op-translator). Aunque nos esforzamos por la precisión, tenga en cuenta que las traducciones automáticas pueden contener errores o inexactitudes. El documento original en su idioma nativo debe considerarse la fuente autorizada. Para información crítica, se recomienda una traducción profesional realizada por humanos. No nos hacemos responsables de ningún malentendido o interpretación errónea derivada del uso de esta traducción.\n",
+    "<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
    ]
   }
  ],
@@ -238,7 +264,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/translations/es/10-ai-agents-production/code_samples/10-python-agent-framework.ipynb
+++ b/translations/es/10-ai-agents-production/code_samples/10-python-agent-framework.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv -q"
+    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv -U -q"
    ]
   },
   {


### PR DESCRIPTION
## Description
Updates lesson 10 notebooks to use the current Microsoft Agent Framework API. `AzureAIProjectAgentProvider` was removed in `agent-framework` v1.8.x and is no longer available under `agent_framework.azure`.

## Problem 1
Running the notebooks fails immediately with:
```python
ImportError: cannot import name 'AzureAIProjectAgentProvider' from 'agent_framework.azure'
```

## Problem 2 - 10-expense_claim-demo.ipynb
The OCR workflow fails with a context window error when the receipt image exists. 

**Root cause**: The notebook passes the receipt image as a base64-encoded string through the text conversation history. `gpt-4o` does not process images passed as base64 text — images must be passed as image_url message types. This is a design issue in the original notebook. **No fix applied for Problem 2** — a markdown note was added to warn users about the limitation.

## Root Cause
The `agent-framework` library underwent a breaking change where Foundry-related clients were moved from `agent_framework.azure` to `agent_framework.foundry`.

Reference: https://learn.microsoft.com/en-us/agent-framework/support/upgrade/python-2026-significant-changes

## Changes
| Before | After |
|--------|-------|
| `from agent_framework.azure import AzureAIProjectAgentProvider` | `from agent_framework.foundry import FoundryChatClient` |
| `AzureAIProjectAgentProvider(credential=AzureCliCredential())` | `FoundryChatClient(project_endpoint=..., model=..., credential=DefaultAzureCredential())` |
| `provider.create_agent(name=..., instructions=..., tools=...)` | `client.as_agent(name=..., instructions=..., tools=...)` |

- Renamed `provider` to `client` for clarity
- Replaced `AzureCliCredential` with `DefaultAzureCredential` for better portability
- Used `%pip install` instead of `! pip install`
- Added `python-dotenv` to install cell
- Added environment variable validation with actionable error message
- Added markdown note in `10-expense_claim-demo.ipynb` warning about context window limitation
- Applied all fixes to both English and Spanish (`translations/es`) notebooks

## Testing
Verified working in GitHub Codespaces with:
- agent-framework: 1.8.1
- Python: 3.12.13
- azure-identity: 1.25.3
- azure-ai-projects: 2.2.0
- Note: 10-expense_claim-demo.ipynb OCR workflow still fails due to Problem 2

## Related
- Closes: 
   - #600
- Related to: 
   - #572 
   - #575 
   - #577 
   - #579 
   - #581 
   - #585 
   - #593 
   - #595

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor