### PR TITLE
fix(lesson-11): replace deprecated AzureAIProjectAgentProvider with FoundryChatClient

### DIFF
--- a/11-agentic-protocols/code_samples/11-a2a-agent-framework.ipynb
+++ b/11-agentic-protocols/code_samples/11-a2a-agent-framework.ipynb
@@ -30,7 +30,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "import asyncio\n",
     "import dotenv\n",
     "from agent_framework import tool, AgentResponseUpdate, WorkflowBuilder\n",
     "from agent_framework.foundry import FoundryChatClient\n",

--- a/11-agentic-protocols/code_samples/11-a2a-agent-framework.ipynb
+++ b/11-agentic-protocols/code_samples/11-a2a-agent-framework.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install agent-framework azure-ai-projects azure-identity"
+    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv"
    ]
   },
   {
@@ -31,9 +31,26 @@
    "source": [
     "import os\n",
     "import asyncio\n",
+    "import dotenv\n",
     "from agent_framework import tool, AgentResponseUpdate, WorkflowBuilder\n",
-    "from agent_framework.azure import AzureAIProjectAgentProvider\n",
-    "from azure.identity import AzureCliCredential"
+    "from agent_framework.foundry import FoundryChatClient\n",
+    "from azure.identity import DefaultAzureCredential\n",
+    "\n",
+    "dotenv.load_dotenv()\n",
+    "\n",
+    "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
+    "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",
+    "\n",
+    "missing = [k for k, v in {\n",
+    "    \"AZURE_AI_PROJECT_ENDPOINT\": endpoint,\n",
+    "    \"AZURE_AI_MODEL_DEPLOYMENT_NAME\": deployment_name\n",
+    "}.items() if not v]\n",
+    "\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variables: {', '.join(missing)}. \"\n",
+    "        \"Please set them as environment variables (e.g., in your .env file or shell environment).\"\n",
+    "    )"
    ]
   },
   {
@@ -42,8 +59,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "provider = AzureAIProjectAgentProvider(credential=AzureCliCredential())"
+    "# Create the Azure AI Foundry client\n",
+    "client = FoundryChatClient(\n",
+    "    project_endpoint=endpoint,\n",
+    "    model=deployment_name,\n",
+    "    credential=DefaultAzureCredential()\n",
+    ")"
    ]
   },
   {
@@ -83,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "currency_agent = await provider.create_agent(\n",
+    "currency_agent = client.as_agent(\n",
     "    name=\"CurrencyExchangeAgent\",\n",
     "    instructions=\"\"\"You are a currency exchange specialist. You help travelers understand:\n",
     "- Current exchange rates between currencies\n",
@@ -92,7 +113,7 @@
     "When asked about a destination, provide relevant currency information.\"\"\",\n",
     ")\n",
     "\n",
-    "activity_agent = await provider.create_agent(\n",
+    "activity_agent = client.as_agent(\n",
     "    name=\"ActivityPlannerAgent\",\n",
     "    instructions=\"\"\"You are a local activities specialist. You recommend:\n",
     "- Must-see attractions and hidden gems\n",
@@ -101,7 +122,7 @@
     "Tailor suggestions to the traveler's interests.\"\"\",\n",
     ")\n",
     "\n",
-    "travel_manager = await provider.create_agent(\n",
+    "travel_manager = client.as_agent(\n",
     "    name=\"TravelManagerAgent\",\n",
     "    instructions=\"\"\"You are a travel manager who coordinates between specialist agents.\n",
     "When planning a trip:\n",
@@ -201,8 +222,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.12.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/11-agentic-protocols/code_samples/11-mcp-agent-framework.ipynb
+++ b/11-agentic-protocols/code_samples/11-mcp-agent-framework.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install agent-framework azure-ai-projects azure-identity -q"
+    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv -q"
    ]
   },
   {
@@ -41,16 +41,38 @@
    "outputs": [],
    "source": [
     "import logging\n",
-    "logging.getLogger(\"agent_framework.azure\").setLevel(logging.ERROR)\n",
+    "logging.getLogger(\"agent_framework.foundry\").setLevel(logging.ERROR)\n",
     "\n",
     "import os\n",
     "import asyncio\n",
+    "import dotenv\n",
     "from typing import Annotated\n",
     "from agent_framework import tool\n",
-    "from agent_framework.azure import AzureAIProjectAgentProvider\n",
-    "from azure.identity import AzureCliCredential\n",
+    "from agent_framework.foundry import FoundryChatClient\n",
+    "from azure.identity import DefaultAzureCredential\n",
     "\n",
-    "provider = AzureAIProjectAgentProvider(credential=AzureCliCredential())"
+    "dotenv.load_dotenv()\n",
+    "\n",
+    "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
+    "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",
+    "\n",
+    "missing = [k for k, v in {\n",
+    "    \"AZURE_AI_PROJECT_ENDPOINT\": endpoint,\n",
+    "    \"AZURE_AI_MODEL_DEPLOYMENT_NAME\": deployment_name\n",
+    "}.items() if not v]\n",
+    "\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variables: {', '.join(missing)}. \"\n",
+    "        \"Please set them as environment variables (e.g., in your .env file or shell environment).\"\n",
+    "    )\n",
+    "\n",
+    "# Create the Azure AI Foundry client\n",
+    "client = FoundryChatClient(\n",
+    "    project_endpoint=endpoint,\n",
+    "    model=deployment_name,\n",
+    "    credential=DefaultAzureCredential()\n",
+    ")"
    ]
   },
   {
@@ -185,7 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent = await provider.create_agent(\n",
+    "agent = client.as_agent(\n",
     "    tools=[search_accommodations, get_local_experiences],\n",
     "    name=\"AccommodationAgent\",\n",
     "    instructions=\"\"\"You are an accommodation and travel experiences specialist powered by MCP-connected services.\n",
@@ -245,8 +267,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.12.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/11-agentic-protocols/code_samples/11-mcp-agent-framework.ipynb
+++ b/11-agentic-protocols/code_samples/11-mcp-agent-framework.ipynb
@@ -44,7 +44,6 @@
     "logging.getLogger(\"agent_framework.foundry\").setLevel(logging.ERROR)\n",
     "\n",
     "import os\n",
-    "import asyncio\n",
     "import dotenv\n",
     "from typing import Annotated\n",
     "from agent_framework import tool\n",

--- a/translations/es/11-agentic-protocols/code_samples/11-a2a-agent-framework.ipynb
+++ b/translations/es/11-agentic-protocols/code_samples/11-a2a-agent-framework.ipynb
@@ -30,7 +30,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "import asyncio\n",
     "import dotenv\n",
     "from agent_framework import tool, AgentResponseUpdate, WorkflowBuilder\n",
     "from agent_framework.foundry import FoundryChatClient\n",

--- a/translations/es/11-agentic-protocols/code_samples/11-a2a-agent-framework.ipynb
+++ b/translations/es/11-agentic-protocols/code_samples/11-a2a-agent-framework.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install agent-framework azure-ai-projects azure-identity"
+    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv"
    ]
   },
   {
@@ -31,9 +31,26 @@
    "source": [
     "import os\n",
     "import asyncio\n",
+    "import dotenv\n",
     "from agent_framework import tool, AgentResponseUpdate, WorkflowBuilder\n",
-    "from agent_framework.azure import AzureAIProjectAgentProvider\n",
-    "from azure.identity import AzureCliCredential"
+    "from agent_framework.foundry import FoundryChatClient\n",
+    "from azure.identity import DefaultAzureCredential\n",
+    "\n",
+    "dotenv.load_dotenv()\n",
+    "\n",
+    "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
+    "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",
+    "\n",
+    "missing = [k for k, v in {\n",
+    "    \"AZURE_AI_PROJECT_ENDPOINT\": endpoint,\n",
+    "    \"AZURE_AI_MODEL_DEPLOYMENT_NAME\": deployment_name\n",
+    "}.items() if not v]\n",
+    "\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variables: {', '.join(missing)}. \"\n",
+    "        \"Please set them as environment variables (e.g., in your .env file or shell environment).\"\n",
+    "    )"
    ]
   },
   {
@@ -42,8 +59,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "provider = AzureAIProjectAgentProvider(credential=AzureCliCredential())"
+    "# Create the Azure AI Foundry client\n",
+    "client = FoundryChatClient(\n",
+    "    project_endpoint=endpoint,\n",
+    "    model=deployment_name,\n",
+    "    credential=DefaultAzureCredential()\n",
+    ")"
    ]
   },
   {
@@ -79,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "currency_agent = await provider.create_agent(\n",
+    "currency_agent = client.as_agent(\n",
     "    name=\"CurrencyExchangeAgent\",\n",
     "    instructions=\"\"\"You are a currency exchange specialist. You help travelers understand:\n",
     "- Current exchange rates between currencies\n",
@@ -88,7 +109,7 @@
     "When asked about a destination, provide relevant currency information.\"\"\",\n",
     ")\n",
     "\n",
-    "activity_agent = await provider.create_agent(\n",
+    "activity_agent = client.as_agent(\n",
     "    name=\"ActivityPlannerAgent\",\n",
     "    instructions=\"\"\"You are a local activities specialist. You recommend:\n",
     "- Must-see attractions and hidden gems\n",
@@ -97,7 +118,7 @@
     "Tailor suggestions to the traveler's interests.\"\"\",\n",
     ")\n",
     "\n",
-    "travel_manager = await provider.create_agent(\n",
+    "travel_manager = client.as_agent(\n",
     "    name=\"TravelManagerAgent\",\n",
     "    instructions=\"\"\"You are a travel manager who coordinates between specialist agents.\n",
     "When planning a trip:\n",
@@ -187,7 +208,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n\n<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n**Aviso legal**:\nEste documento ha sido traducido utilizando el servicio de traducción automática [Co-op Translator](https://github.com/Azure/co-op-translator). Aunque nos esforzamos por la precisión, tenga en cuenta que las traducciones automáticas pueden contener errores o inexactitudes. El documento original en su idioma nativo debe considerarse la fuente autorizada. Para información crítica, se recomienda una traducción profesional realizada por humanos. No nos responsabilizamos por malentendidos o interpretaciones erróneas derivados del uso de esta traducción.\n<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
+    "---\n",
+    "\n",
+    "<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n",
+    "**Aviso legal**:\n",
+    "Este documento ha sido traducido utilizando el servicio de traducción automática [Co-op Translator](https://github.com/Azure/co-op-translator). Aunque nos esforzamos por la precisión, tenga en cuenta que las traducciones automáticas pueden contener errores o inexactitudes. El documento original en su idioma nativo debe considerarse la fuente autorizada. Para información crítica, se recomienda una traducción profesional realizada por humanos. No nos responsabilizamos por malentendidos o interpretaciones erróneas derivados del uso de esta traducción.\n",
+    "<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
    ]
   }
  ],
@@ -198,8 +224,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.12.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/translations/es/11-agentic-protocols/code_samples/11-mcp-agent-framework.ipynb
+++ b/translations/es/11-agentic-protocols/code_samples/11-mcp-agent-framework.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install agent-framework azure-ai-projects azure-identity -q"
+    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv -q"
    ]
   },
   {
@@ -41,16 +41,38 @@
    "outputs": [],
    "source": [
     "import logging\n",
-    "logging.getLogger(\"agent_framework.azure\").setLevel(logging.ERROR)\n",
+    "logging.getLogger(\"agent_framework.foundry\").setLevel(logging.ERROR)\n",
     "\n",
     "import os\n",
     "import asyncio\n",
+    "import dotenv\n",
     "from typing import Annotated\n",
     "from agent_framework import tool\n",
-    "from agent_framework.azure import AzureAIProjectAgentProvider\n",
-    "from azure.identity import AzureCliCredential\n",
+    "from agent_framework.foundry import FoundryChatClient\n",
+    "from azure.identity import DefaultAzureCredential\n",
     "\n",
-    "provider = AzureAIProjectAgentProvider(credential=AzureCliCredential())"
+    "dotenv.load_dotenv()\n",
+    "\n",
+    "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
+    "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",
+    "\n",
+    "missing = [k for k, v in {\n",
+    "    \"AZURE_AI_PROJECT_ENDPOINT\": endpoint,\n",
+    "    \"AZURE_AI_MODEL_DEPLOYMENT_NAME\": deployment_name\n",
+    "}.items() if not v]\n",
+    "\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variables: {', '.join(missing)}. \"\n",
+    "        \"Please set them as environment variables (e.g., in your .env file or shell environment).\"\n",
+    "    )\n",
+    "\n",
+    "# Create the Azure AI Foundry client\n",
+    "client = FoundryChatClient(\n",
+    "    project_endpoint=endpoint,\n",
+    "    model=deployment_name,\n",
+    "    credential=DefaultAzureCredential()\n",
+    ")"
    ]
   },
   {
@@ -185,7 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent = await provider.create_agent(\n",
+    "agent = client.as_agent(\n",
     "    tools=[search_accommodations, get_local_experiences],\n",
     "    name=\"AccommodationAgent\",\n",
     "    instructions=\"\"\"You are an accommodation and travel experiences specialist powered by MCP-connected services.\n",
@@ -241,7 +263,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n\n<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n**Aviso legal**:  \nEste documento ha sido traducido utilizando el servicio de traducción automática [Co-op Translator](https://github.com/Azure/co-op-translator). Aunque nos esforzamos por la precisión, tenga en cuenta que las traducciones automáticas pueden contener errores o inexactitudes. El documento original en su idioma nativo debe considerarse la fuente autorizada. Para información crítica, se recomienda una traducción profesional realizada por humanos. No nos hacemos responsables de malentendidos o interpretaciones erróneas derivadas del uso de esta traducción.\n<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
+    "---\n",
+    "\n",
+    "<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n",
+    "**Aviso legal**:  \n",
+    "Este documento ha sido traducido utilizando el servicio de traducción automática [Co-op Translator](https://github.com/Azure/co-op-translator). Aunque nos esforzamos por la precisión, tenga en cuenta que las traducciones automáticas pueden contener errores o inexactitudes. El documento original en su idioma nativo debe considerarse la fuente autorizada. Para información crítica, se recomienda una traducción profesional realizada por humanos. No nos hacemos responsables de malentendidos o interpretaciones erróneas derivadas del uso de esta traducción.\n",
+    "<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
    ]
   }
  ],
@@ -252,8 +279,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.12.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/translations/es/11-agentic-protocols/code_samples/11-mcp-agent-framework.ipynb
+++ b/translations/es/11-agentic-protocols/code_samples/11-mcp-agent-framework.ipynb
@@ -44,7 +44,6 @@
     "logging.getLogger(\"agent_framework.foundry\").setLevel(logging.ERROR)\n",
     "\n",
     "import os\n",
-    "import asyncio\n",
     "import dotenv\n",
     "from typing import Annotated\n",
     "from agent_framework import tool\n",


### PR DESCRIPTION
## Description
Updates lesson 11 notebooks to use the current Microsoft Agent Framework API. `AzureAIProjectAgentProvider` was removed in `agent-framework` v1.8.x and is no longer available under `agent_framework.azure`.

## Problem
Running the notebooks fails immediately with:
```python
ImportError: cannot import name 'AzureAIProjectAgentProvider' from 'agent_framework.azure'
```

## Root Cause
The `agent-framework` library underwent a breaking change where Foundry-related clients were moved from `agent_framework.azure` to `agent_framework.foundry`.

Reference: https://learn.microsoft.com/en-us/agent-framework/support/upgrade/python-2026-significant-changes

## Changes
| Before | After |
|--------|-------|
| `from agent_framework.azure import AzureAIProjectAgentProvider` | `from agent_framework.foundry import FoundryChatClient` |
| `AzureAIProjectAgentProvider(credential=AzureCliCredential())` | `FoundryChatClient(project_endpoint=..., model=..., credential=DefaultAzureCredential())` |
| `provider.create_agent(name=..., instructions=..., tools=...)` | `client.as_agent(name=..., instructions=..., tools=...)` |

- Renamed `provider` to `client` for clarity
- Replaced `AzureCliCredential` with `DefaultAzureCredential` for better portability
- Added `python-dotenv` to install cell
- Added environment variable validation with actionable error message
- Applied all fixes to both English and Spanish (`translations/es`) notebooks

## Testing
Verified working in GitHub Codespaces with:
- agent-framework: 1.8.1
- Python: 3.12.13
- azure-identity: 1.25.3
- azure-ai-projects: 2.2.0

## Related
- Closes: 
   - #603 
- Related to: 
   - #572 
   - #575 
   - #577 
   - #579 
   - #581 
   - #585 
   - #593 
   - #595
   - #600 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor