### PR TITLE
Enhance disclaimer with hyperlink in Japanese translation

### DIFF
--- a/translations/ja/05-agentic-rag/code_samples/05-python-agent-framework.ipynb
+++ b/translations/ja/05-agentic-rag/code_samples/05-python-agent-framework.ipynb
@@ -220,7 +220,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n\n<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n**免責事項**：  \n本書類はAI翻訳サービス「Co-op Translator」（https://github.com/Azure/co-op-translator）を利用して翻訳されました。正確性には努めておりますが、自動翻訳には誤りや不正確な部分が含まれる可能性があります。原文の母語版を権威ある情報源としてご参照ください。重要な情報については、専門の翻訳者による翻訳を推奨いたします。本翻訳の利用により生じたいかなる誤解や誤訳についても、当方は責任を負いかねます。\n<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
+    "---\n\n<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n**免責事項**：  \n本書類はAI翻訳サービス「[Co-op Translator](https://github.com/Azure/co-op-translator)」を利用して翻訳されました。正確性には努めておりますが、自動翻訳には誤りや不正確な部分が含まれる可能性があります。原文の母語版を権威ある情報源としてご参照ください。重要な情報については、専門の翻訳者による翻訳を推奨いたします。本翻訳の利用により生じたいかなる誤解や誤訳についても、当方は責任を負いかねます。\n<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
    ]
   }
  ],


### PR DESCRIPTION
Updated the disclaimer section in the Japanese translation to include a hyperlink for Co-op Translator. 
https://github.com/microsoft/ai-agents-for-beginners/blob/main/translations/ja/05-agentic-rag/code_samples/05-python-agent-framework.ipynb

<img width="1164" height="172" alt="image" src="https://github.com/user-attachments/assets/394e6fe8-edee-4011-aa8b-9ff71441856c" />

related https://github.com/Azure/co-op-translator/issues/363

 #PingMSFTDocs