### PR TITLE
fix(lesson-12): replace deprecated AzureAIProjectAgentProvider with FoundryChatClient

### DIFF
--- a/12-context-engineering/code_samples/12-chat_summarization.ipynb
+++ b/12-context-engineering/code_samples/12-chat_summarization.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install agent-framework azure-ai-projects azure-identity --quiet"
+    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv --quiet"
    ]
   },
   {
@@ -43,14 +43,13 @@
    "source": [
     "import os\n",
     "import asyncio\n",
+    "import dotenv\n",
     "from datetime import datetime\n",
     "from pathlib import Path\n",
     "\n",
-    "from dotenv import load_dotenv\n",
-    "\n",
     "from agent_framework import tool\n",
-    "from agent_framework.azure import AzureAIProjectAgentProvider\n",
-    "from azure.identity import AzureCliCredential"
+    "from agent_framework.foundry import FoundryChatClient\n",
+    "from azure.identity import DefaultAzureCredential"
    ]
   },
   {
@@ -59,12 +58,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load environment variables and create Azure AI Foundry provider\n",
-    "load_dotenv()\n",
+    "dotenv.load_dotenv()\n",
     "\n",
-    "provider = AzureAIProjectAgentProvider(credential=AzureCliCredential())\n",
+    "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
+    "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",
     "\n",
-    "print(\"✅ Azure AI Foundry provider configured\")\n"
+    "missing = [k for k, v in {\n",
+    "    \"AZURE_AI_PROJECT_ENDPOINT\": endpoint,\n",
+    "    \"AZURE_AI_MODEL_DEPLOYMENT_NAME\": deployment_name\n",
+    "}.items() if not v]\n",
+    "\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variables: {', '.join(missing)}. \"\n",
+    "        \"Please set them as environment variables (e.g., in your .env file or shell environment).\"\n",
+    "    )\n",
+    "\n",
+    "# Create the Azure AI Foundry client\n",
+    "client = FoundryChatClient(\n",
+    "    project_endpoint=endpoint,\n",
+    "    model=deployment_name,\n",
+    "    credential=DefaultAzureCredential()\n",
+    ")\n",
+    "\n",
+    "print(\"Azure AI Foundry client configured\")"
    ]
   },
   {
@@ -103,7 +120,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent = await provider.create_agent(\n",
+    "agent = client.as_agent(\n",
     "    name=\"ContextAwareAgent\",\n",
     "    instructions=\"\"\"You are a helpful travel planning assistant with excellent memory management.\n",
     "When conversations get long:\n",
@@ -113,7 +130,7 @@
     "Always maintain continuity while being concise.\"\"\",\n",
     ")\n",
     "\n",
-    "print(\"🤖 Context-aware travel planning agent created\")"
+    "print(\"Context-aware travel planning agent created\")"
    ]
   },
   {
@@ -203,7 +220,7 @@
     "\n",
     "\n",
     "# Create an enhanced agent with the summarization tool\n",
-    "summarizing_agent = await provider.create_agent(\n",
+    "summarizing_agent = client.as_agent(\n",
     "    name=\"SummarizingTravelAgent\",\n",
     "    instructions=\"\"\"You are a helpful travel planning assistant that actively manages conversation context.\n",
     "\n",
@@ -220,7 +237,7 @@
     "    tools=[summarize_preferences],\n",
     ")\n",
     "\n",
-    "print(\"🤖 Summarizing travel agent created with context tools\")"
+    "print(\"Summarizing travel agent created with context tools\")"
    ]
   },
   {
@@ -296,7 +313,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/translations/es/12-context-engineering/code_samples/12-chat_summarization.ipynb
+++ b/translations/es/12-context-engineering/code_samples/12-chat_summarization.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install agent-framework azure-ai-projects azure-identity --quiet"
+    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv --quiet"
    ]
   },
   {
@@ -43,14 +43,13 @@
    "source": [
     "import os\n",
     "import asyncio\n",
+    "import dotenv\n",
     "from datetime import datetime\n",
     "from pathlib import Path\n",
     "\n",
-    "from dotenv import load_dotenv\n",
-    "\n",
     "from agent_framework import tool\n",
-    "from agent_framework.azure import AzureAIProjectAgentProvider\n",
-    "from azure.identity import AzureCliCredential"
+    "from agent_framework.foundry import FoundryChatClient\n",
+    "from azure.identity import DefaultAzureCredential"
    ]
   },
   {
@@ -59,12 +58,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load environment variables and create Azure AI Foundry provider\n",
-    "load_dotenv()\n",
+    "dotenv.load_dotenv()\n",
     "\n",
-    "provider = AzureAIProjectAgentProvider(credential=AzureCliCredential())\n",
+    "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
+    "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",
     "\n",
-    "print(\"✅ Azure AI Foundry provider configured\")\n"
+    "missing = [k for k, v in {\n",
+    "    \"AZURE_AI_PROJECT_ENDPOINT\": endpoint,\n",
+    "    \"AZURE_AI_MODEL_DEPLOYMENT_NAME\": deployment_name\n",
+    "}.items() if not v]\n",
+    "\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variables: {', '.join(missing)}. \"\n",
+    "        \"Please set them as environment variables (e.g., in your .env file or shell environment).\"\n",
+    "    )\n",
+    "\n",
+    "# Create the Azure AI Foundry client\n",
+    "client = FoundryChatClient(\n",
+    "    project_endpoint=endpoint,\n",
+    "    model=deployment_name,\n",
+    "    credential=DefaultAzureCredential()\n",
+    ")\n",
+    "\n",
+    "print(\"Azure AI Foundry client configured\")"
    ]
   },
   {
@@ -103,7 +120,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent = await provider.create_agent(\n",
+    "agent = client.as_agent(\n",
     "    name=\"ContextAwareAgent\",\n",
     "    instructions=\"\"\"You are a helpful travel planning assistant with excellent memory management.\n",
     "When conversations get long:\n",
@@ -113,7 +130,7 @@
     "Always maintain continuity while being concise.\"\"\",\n",
     ")\n",
     "\n",
-    "print(\"🤖 Context-aware travel planning agent created\")"
+    "print(\"Context-aware travel planning agent created\")"
    ]
   },
   {
@@ -203,7 +220,7 @@
     "\n",
     "\n",
     "# Create an enhanced agent with the summarization tool\n",
-    "summarizing_agent = await provider.create_agent(\n",
+    "summarizing_agent = client.as_agent(\n",
     "    name=\"SummarizingTravelAgent\",\n",
     "    instructions=\"\"\"You are a helpful travel planning assistant that actively manages conversation context.\n",
     "\n",
@@ -220,7 +237,7 @@
     "    tools=[summarize_preferences],\n",
     ")\n",
     "\n",
-    "print(\"🤖 Summarizing travel agent created with context tools\")"
+    "print(\"Summarizing travel agent created with context tools\")"
    ]
   },
   {
@@ -283,7 +300,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n\n<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n**Aviso Legal**:\nEste documento ha sido traducido utilizando el servicio de traducción automática [Co-op Translator](https://github.com/Azure/co-op-translator). Aunque nos esforzamos por lograr precisión, tenga en cuenta que las traducciones automáticas pueden contener errores o inexactitudes. El documento original en su idioma nativo debe considerarse la fuente autorizada. Para información crítica, se recomienda una traducción profesional realizada por humanos. No nos responsabilizamos por cualquier malentendido o interpretación errónea derivada del uso de esta traducción.\n<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
+    "---\n",
+    "\n",
+    "<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n",
+    "**Aviso Legal**:\n",
+    "Este documento ha sido traducido utilizando el servicio de traducción automática [Co-op Translator](https://github.com/Azure/co-op-translator). Aunque nos esforzamos por lograr precisión, tenga en cuenta que las traducciones automáticas pueden contener errores o inexactitudes. El documento original en su idioma nativo debe considerarse la fuente autorizada. Para información crítica, se recomienda una traducción profesional realizada por humanos. No nos responsabilizamos por cualquier malentendido o interpretación errónea derivada del uso de esta traducción.\n",
+    "<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
    ]
   }
  ],
@@ -303,7 +325,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description
Updates lesson 12 notebook to use the current Microsoft Agent Framework API. `AzureAIProjectAgentProvider` was removed in `agent-framework` v1.8.x and is no longer available under `agent_framework.azure`.

## Problem
Running the notebook fails immediately with:
```python
ImportError: cannot import name 'AzureAIProjectAgentProvider' from 'agent_framework.azure'
```

## Root Cause
The `agent-framework` library underwent a breaking change where Foundry-related clients were moved from `agent_framework.azure` to `agent_framework.foundry`.

Reference: https://learn.microsoft.com/en-us/agent-framework/support/upgrade/python-2026-significant-changes

## Changes
| Before | After |
|--------|-------|
| `from agent_framework.azure import AzureAIProjectAgentProvider` | `from agent_framework.foundry import FoundryChatClient` |
| `AzureAIProjectAgentProvider(credential=AzureCliCredential())` | `FoundryChatClient(project_endpoint=..., model=..., credential=DefaultAzureCredential())` |
| `provider.create_agent(name=..., instructions=..., tools=...)` | `client.as_agent(name=..., instructions=..., tools=...)` |

- Renamed `provider` to `client` for clarity
- Replaced `AzureCliCredential` with `DefaultAzureCredential` for better portability
- Added `python-dotenv` to install cell
- Added environment variable validation with actionable error message
- Removed emoji from print statements for cleaner output
- Applied all fixes to both English and Spanish (`translations/es`) notebooks

## Testing
Verified working in GitHub Codespaces with:
- agent-framework: 1.8.1
- Python: 3.12.13
- azure-identity: 1.25.3
- azure-ai-projects: 2.2.0

## Related
- Closes: 
   - #619 
- Related to:
   - #572 
   - #575 
   - #577 
   - #579 
   - #581 
   - #585 
   - #593 
   - #595
   - #600 
   - #603 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor