### PR TITLE
fix(lesson-13): replace deprecated AzureAIProjectAgentProvider and fix tool definition order in 13-agent-memory.ipynb

### DIFF
--- a/13-agent-memory/13-agent-memory.ipynb
+++ b/13-agent-memory/13-agent-memory.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install agent-framework azure-ai-projects azure-identity -q"
+    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv -q"
    ]
   },
   {
@@ -40,20 +40,33 @@
    "outputs": [],
    "source": [
     "import logging\n",
-    "logging.getLogger(\"agent_framework.azure\").setLevel(logging.ERROR)\n",
+    "logging.getLogger(\"agent_framework.foundry\").setLevel(logging.ERROR)\n",
     "\n",
     "import os\n",
     "import json\n",
+    "import dotenv\n",
     "from typing import Annotated\n",
     "from datetime import datetime\n",
     "\n",
-    "from dotenv import load_dotenv\n",
-    "\n",
     "from agent_framework import tool\n",
-    "from agent_framework.azure import AzureAIProjectAgentProvider\n",
-    "from azure.identity import AzureCliCredential\n",
+    "from agent_framework.foundry import FoundryChatClient\n",
+    "from azure.identity import DefaultAzureCredential\n",
     "\n",
-    "load_dotenv()"
+    "dotenv.load_dotenv()\n",
+    "\n",
+    "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
+    "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",
+    "\n",
+    "missing = [k for k, v in {\n",
+    "    \"AZURE_AI_PROJECT_ENDPOINT\": endpoint,\n",
+    "    \"AZURE_AI_MODEL_DEPLOYMENT_NAME\": deployment_name\n",
+    "}.items() if not v]\n",
+    "\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variables: {', '.join(missing)}. \"\n",
+    "        \"Please set them as environment variables (e.g., in your .env file or shell environment).\"\n",
+    "    )"
    ]
   },
   {
@@ -62,9 +75,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "provider = AzureAIProjectAgentProvider(credential=AzureCliCredential())\n",
+    "# Create the Azure AI Foundry client\n",
+    "client = FoundryChatClient(\n",
+    "    project_endpoint=endpoint,\n",
+    "    model=deployment_name,\n",
+    "    credential=DefaultAzureCredential()\n",
+    ")\n",
     "\n",
-    "print(\"✅ AzureAIProjectAgentProvider created\")"
+    "print(\"Azure AI Foundry client configured\")"
    ]
   },
   {
@@ -102,8 +120,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent = await provider.create_agent(\n",
-    "    tools=[save_preference, get_preferences],\n",
+    "agent = client.as_agent(\n",
     "    name=\"TravelMemoryAgent\",\n",
     "    instructions=(\n",
     "        \"You are a travel agent who remembers user preferences across conversations. \"\n",
@@ -250,7 +267,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "travel_agent = await provider.create_agent(\n",
+    "travel_agent = client.as_agent(\n",
     "    tools=[save_preference, get_preferences],\n",
     "    name=\"TravelBookingAssistant\",\n",
     "    instructions=(\n",
@@ -393,7 +410,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/translations/es/13-agent-memory/13-agent-memory.ipynb
+++ b/translations/es/13-agent-memory/13-agent-memory.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install agent-framework azure-ai-projects azure-identity -q"
+    "%pip install agent-framework azure-ai-projects azure-identity python-dotenv -q"
    ]
   },
   {
@@ -40,20 +40,33 @@
    "outputs": [],
    "source": [
     "import logging\n",
-    "logging.getLogger(\"agent_framework.azure\").setLevel(logging.ERROR)\n",
+    "logging.getLogger(\"agent_framework.foundry\").setLevel(logging.ERROR)\n",
     "\n",
     "import os\n",
     "import json\n",
+    "import dotenv\n",
     "from typing import Annotated\n",
     "from datetime import datetime\n",
     "\n",
-    "from dotenv import load_dotenv\n",
-    "\n",
     "from agent_framework import tool\n",
-    "from agent_framework.azure import AzureAIProjectAgentProvider\n",
-    "from azure.identity import AzureCliCredential\n",
+    "from agent_framework.foundry import FoundryChatClient\n",
+    "from azure.identity import DefaultAzureCredential\n",
     "\n",
-    "load_dotenv()"
+    "dotenv.load_dotenv()\n",
+    "\n",
+    "endpoint = os.getenv(\"AZURE_AI_PROJECT_ENDPOINT\")\n",
+    "deployment_name = os.getenv(\"AZURE_AI_MODEL_DEPLOYMENT_NAME\")\n",
+    "\n",
+    "missing = [k for k, v in {\n",
+    "    \"AZURE_AI_PROJECT_ENDPOINT\": endpoint,\n",
+    "    \"AZURE_AI_MODEL_DEPLOYMENT_NAME\": deployment_name\n",
+    "}.items() if not v]\n",
+    "\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variables: {', '.join(missing)}. \"\n",
+    "        \"Please set them as environment variables (e.g., in your .env file or shell environment).\"\n",
+    "    )"
    ]
   },
   {
@@ -62,9 +75,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "provider = AzureAIProjectAgentProvider(credential=AzureCliCredential())\n",
+    "# Create the Azure AI Foundry client\n",
+    "client = FoundryChatClient(\n",
+    "    project_endpoint=endpoint,\n",
+    "    model=deployment_name,\n",
+    "    credential=DefaultAzureCredential()\n",
+    ")\n",
     "\n",
-    "print(\"✅ AzureAIProjectAgentProvider created\")"
+    "print(\"Azure AI Foundry client configured\")"
    ]
   },
   {
@@ -102,8 +120,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent = await provider.create_agent(\n",
-    "    tools=[save_preference, get_preferences],\n",
+    "agent = client.as_agent(\n",
     "    name=\"TravelMemoryAgent\",\n",
     "    instructions=(\n",
     "        \"You are a travel agent who remembers user preferences across conversations. \"\n",
@@ -250,7 +267,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "travel_agent = await provider.create_agent(\n",
+    "travel_agent = client.as_agent(\n",
     "    tools=[save_preference, get_preferences],\n",
     "    name=\"TravelBookingAssistant\",\n",
     "    instructions=(\n",
@@ -380,7 +397,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n\n<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n**Aviso legal**:\nEste documento ha sido traducido utilizando el servicio de traducción automática [Co-op Translator](https://github.com/Azure/co-op-translator). Aunque nos esforzamos por la precisión, tenga en cuenta que las traducciones automáticas pueden contener errores o inexactitudes. El documento original en su idioma nativo debe considerarse la fuente autorizada. Para información crítica, se recomienda la traducción profesional por humanos. No nos hacemos responsables de malentendidos o interpretaciones erróneas derivadas del uso de esta traducción.\n<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
+    "---\n",
+    "\n",
+    "<!-- CO-OP TRANSLATOR DISCLAIMER START -->\n",
+    "**Aviso legal**:\n",
+    "Este documento ha sido traducido utilizando el servicio de traducción automática [Co-op Translator](https://github.com/Azure/co-op-translator). Aunque nos esforzamos por la precisión, tenga en cuenta que las traducciones automáticas pueden contener errores o inexactitudes. El documento original en su idioma nativo debe considerarse la fuente autorizada. Para información crítica, se recomienda la traducción profesional por humanos. No nos hacemos responsables de malentendidos o interpretaciones erróneas derivadas del uso de esta traducción.\n",
+    "<!-- CO-OP TRANSLATOR DISCLAIMER END -->\n"
    ]
   }
  ],
@@ -400,7 +422,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description
Updates lesson 13 notebook to use the current Microsoft Agent Framework API and fixes a NameError caused by tools being referenced before they are defined.

## Problem 1
`AzureAIProjectAgentProvider` was removed in `agent-framework` v1.8.x and is no longer available under `agent_framework.azure`.

Running the notebook fails immediately with:
```python
ImportError: cannot import name 'AzureAIProjectAgentProvider' from 'agent_framework.azure'
```

## Problem 2
The Working Memory section references `save_preference` and `get_preferences` tools that are not defined until the Long-Term Memory section, causing:
```python
NameError: name 'save_preference' is not defined
```

## Root Cause
The `agent-framework` library underwent a breaking change where Foundry-related clients were moved from `agent_framework.azure` to `agent_framework.foundry`.

Reference: https://learn.microsoft.com/en-us/agent-framework/support/upgrade/python-2026-significant-changes

## Changes
| Before | After |
|--------|-------|
| `from agent_framework.azure import AzureAIProjectAgentProvider` | `from agent_framework.foundry import FoundryChatClient` |
| `AzureAIProjectAgentProvider(credential=AzureCliCredential())` | `FoundryChatClient(project_endpoint=..., model=..., credential=DefaultAzureCredential())` |
| `provider.create_agent(name=..., instructions=..., tools=...)` | `client.as_agent(name=..., instructions=..., tools=...)` |

- Removed `tools=[save_preference, get_preferences]` from Working Memory agent
  since those tools are not needed to demonstrate working memory
- Renamed `provider` to `client` for clarity
- Replaced `AzureCliCredential` with `DefaultAzureCredential` for better portability
- Added `python-dotenv` to install cell
- Added environment variable validation with actionable error message
- Applied all fixes to both English and Spanish (`translations/es`) notebooks

## Known Issue
`13-agent-memory-cognee.ipynb` requires additional configuration for Azure OpenAI embeddings with cognee that is not yet documented. This notebook is not modified in this PR. See related issue for details.

## Testing
Verified working in GitHub Codespaces with:
- agent-framework: 1.8.1
- Python: 3.12.13
- azure-identity: 1.25.3
- azure-ai-projects: 2.2.0

## Related
- Closes: 
   - #623 
- Related to:
   - #572 
   - #575 
   - #577 
   - #579 
   - #581
   - #585 
   - #593 
   - #595
   - #600 
   - #603 
   - #619 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor