### PR TITLE
Fix #609: avoid logging raw fenced JSON in DraftExecutor

### DIFF
--- a/08-multi-agent/code_samples/workflows-agent-framework/dotNET/04.dotnet-agent-framework-workflow-aifoundry-condition.cs
+++ b/08-multi-agent/code_samples/workflows-agent-framework/dotNET/04.dotnet-agent-framework-workflow-aifoundry-condition.cs
@@ -217,13 +217,11 @@ public class DraftExecutor : ReflectingExecutor<DraftExecutor>, IMessageHandler<
         
         var response = await this._evangelistAgent.RunAsync(message);
         
-        Console.WriteLine($"DraftExecutor response: {response.Text}");
-        
         // The agent may wrap its JSON result in a Markdown code block (```json ... ```),
         // so extract the JSON object before deserializing it into a ContentResult.
         var contentResult = JsonSerializer.Deserialize<ContentResult>(ExtractJson(response.Text)) ?? new ContentResult { DraftContent = response.Text ?? string.Empty };
         
-        Console.WriteLine($"DraftExecutor generated content: {contentResult.DraftContent}");
+        Console.WriteLine($"DraftExecutor generated draft length: {contentResult.DraftContent?.Length ?? 0}");
         
         return contentResult;
     }

--- a/08-multi-agent/code_samples/workflows-agent-framework/dotNET/04.dotnet-agent-framework-workflow-aifoundry-condition.ipynb
+++ b/08-multi-agent/code_samples/workflows-agent-framework/dotNET/04.dotnet-agent-framework-workflow-aifoundry-condition.ipynb
@@ -719,6 +719,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e54e5906",
    "metadata": {
     "language_info": {
      "name": "polyglot-notebook"
@@ -750,13 +751,11 @@
     "\n",
     "        var response = await this._evangelistAgent.RunAsync(message);\n",
     "\n",
-    "        Console.WriteLine($\"DraftExecutor response: {response.Text}\");\n",
-    "\n",
     "        // The agent may wrap its JSON result in a Markdown code block (```json ... ```),\n",
     "        // so extract the JSON object before deserializing it into a ContentResult.\n",
     "        var contentResult = JsonSerializer.Deserialize<ContentResult>(ExtractJson(response.Text)) ?? new ContentResult { DraftContent = response.Text ?? string.Empty };\n",
     "\n",
-    "        Console.WriteLine($\"DraftExecutor generated content: {contentResult.DraftContent}\");\n",
+    "        Console.WriteLine($\"DraftExecutor generated draft length: {contentResult.DraftContent?.Length ?? 0}\");\n",
     "\n",
     "        return contentResult;\n",
     "    }\n",


### PR DESCRIPTION
## Summary

Fixes #609.

The conditional-workflow sample's `DraftExecutor` logged the raw agent response, which can contain a Markdown-fenced JSON block (```` ```json ... ``` ````). When this landed in notebook output it broke fenced-JSON rendering. This PR removes that logging and logs only the draft length instead.

## Changes

| File | Description |
| --- | --- |
| `08-multi-agent/code_samples/workflows-agent-framework/dotNET/04.dotnet-agent-framework-workflow-aifoundry-condition.ipynb` | Removes raw response logging so no fenced JSON is written to notebook output. Notebook has no executed cells (no stale outputs). |
| `08-multi-agent/code_samples/workflows-agent-framework/dotNET/04.dotnet-agent-framework-workflow-aifoundry-condition.cs` | Removes raw response logging and logs only the draft length to avoid saving fenced JSON into outputs. |

### Before
```csharp
Console.WriteLine($"DraftExecutor response: {response.Text}");
...
Console.WriteLine($"DraftExecutor generated content: {contentResult.DraftContent}");
```

### After
```csharp
Console.WriteLine($"DraftExecutor generated draft length: {contentResult.DraftContent?.Length ?? 0}");
```

## Notes
- No behavioral change to the workflow — only diagnostic logging was adjusted.
- Not executed against live Azure; .NET not compiled locally.