### PR TITLE
fix(lesson-01): update agent creation

### DIFF
--- a/01-intro-to-ai-agents/code_samples/01-dotnet-agent-framework.cs
+++ b/01-intro-to-ai-agents/code_samples/01-dotnet-agent-framework.cs
@@ -4,7 +4,6 @@
 #:package Microsoft.Agents.AI.OpenAI@1.1.0
 #:package Azure.AI.OpenAI@2.1.0
 #:package Azure.Identity@1.13.1
-#:package DotNetEnv@3.1.1
 
 using System.ComponentModel;
 
@@ -14,11 +13,6 @@ using Microsoft.Extensions.AI;
 using Azure.AI.OpenAI;
 using Azure.Identity;
 using OpenAI.Chat;
-
-using DotNetEnv;
-
-// Load environment variables
-Env.Load("../../.env");
 
 // Tool Function: Random Destination Generator
 // This static method will be available to the agent as a callable tool

--- a/01-intro-to-ai-agents/code_samples/01-dotnet-agent-framework.cs
+++ b/01-intro-to-ai-agents/code_samples/01-dotnet-agent-framework.cs
@@ -4,6 +4,7 @@
 #:package Microsoft.Agents.AI.OpenAI@1.1.0
 #:package Azure.AI.OpenAI@2.1.0
 #:package Azure.Identity@1.13.1
+#:package DotNetEnv@3.1.1
 
 using System.ComponentModel;
 
@@ -12,6 +13,13 @@ using Microsoft.Extensions.AI;
 
 using Azure.AI.OpenAI;
 using Azure.Identity;
+
+using OpenAI.Chat;
+
+using DotNetEnv;
+
+// Load environment variables
+Env.Load();
 
 // Tool Function: Random Destination Generator
 // This static method will be available to the agent as a callable tool
@@ -55,8 +63,8 @@ var azureClient = new AzureOpenAIClient(new Uri(azureEndpoint), new AzureCliCred
 // Configure agent with name, instructions, and available tools
 // The agent can now plan trips using the GetRandomDestination function
 AIAgent agent = azureClient
-    .GetOpenAIResponseClient(deployment)
-    .CreateAIAgent(
+    .GetChatClient(deployment)
+    .AsAIAgent(
         instructions: "You are a helpful AI Agent that can help plan vacations for customers at random destinations",
         tools: [AIFunctionFactory.Create(GetRandomDestination)]
     );

--- a/01-intro-to-ai-agents/code_samples/01-dotnet-agent-framework.cs
+++ b/01-intro-to-ai-agents/code_samples/01-dotnet-agent-framework.cs
@@ -18,7 +18,7 @@ using OpenAI.Chat;
 using DotNetEnv;
 
 // Load environment variables
-Env.Load("../../../.env");
+Env.Load("../../.env");
 
 // Tool Function: Random Destination Generator
 // This static method will be available to the agent as a callable tool

--- a/01-intro-to-ai-agents/code_samples/01-dotnet-agent-framework.cs
+++ b/01-intro-to-ai-agents/code_samples/01-dotnet-agent-framework.cs
@@ -13,13 +13,12 @@ using Microsoft.Extensions.AI;
 
 using Azure.AI.OpenAI;
 using Azure.Identity;
-
 using OpenAI.Chat;
 
 using DotNetEnv;
 
 // Load environment variables
-Env.Load();
+Env.Load("../../../.env");
 
 // Tool Function: Random Destination Generator
 // This static method will be available to the agent as a callable tool

--- a/01-intro-to-ai-agents/code_samples/01-dotnet-agent-framework.md
+++ b/01-intro-to-ai-agents/code_samples/01-dotnet-agent-framework.md
@@ -85,8 +85,8 @@ See [`01-dotnet-agent-framework.cs`](./01-dotnet-agent-framework.cs) for the com
 ```csharp
 #!/usr/bin/dotnet run
 
-#:package Microsoft.Extensions.AI@9.*
-#:package Microsoft.Agents.AI.OpenAI@1.*-*
+#:package Microsoft.Extensions.AI@10.4.1
+#:package Microsoft.Agents.AI.OpenAI@1.1.0
 #:package Azure.AI.OpenAI@2.1.0
 #:package Azure.Identity@1.13.1
 
@@ -140,8 +140,8 @@ var azureClient = new AzureOpenAIClient(new Uri(azureEndpoint), new AzureCliCred
 // Configure agent with travel planning instructions and random destination tool
 // The agent can now plan trips using the GetRandomDestination function
 AIAgent agent = azureClient
-    .GetOpenAIResponseClient(deployment)
-    .CreateAIAgent(
+    .GetChatClient(deployment)
+    .AsAIAgent(
         instructions: "You are a helpful AI Agent that can help plan vacations for customers at random destinations",
         tools: [AIFunctionFactory.Create(GetRandomDestination)]
     );


### PR DESCRIPTION
**Summary**  
This PR updates the Lesson 01 .NET agent framework sample to improve compatibility with the latest APIs.

**Changes**

- Updated agent instantiation to use `GetChatClient` and `AsAIAgent`, replacing `GetOpenAIResponseClient` (`AsAIAgent` creates an AI agent from an `OpenAI.Chat.ChatClient`).
- Added necessary using directives for new functionality.
- Ensured sample runs correctly

Addresses Issue: #639

**Why**  

The previous sample referenced `GetOpenAIResponseClient`, which is not available in the current `AzureOpenAIClient SDK`. The correct approach is to use `OpenAI.Chat.ChatClient.GetChatClient` with `AsAIAgent`. This update aligns the sample with the latest stable APIs.

**Testing**

- Verified compilation and execution using .NET 10.0.301 SDK.
- Confirmed agent creation works as expected with updated APIs.