### PR TITLE
fix(lesson-02): update agent creation

### DIFF
--- a/02-explore-agentic-frameworks/code_samples/02-dotnet-agent-framework.cs
+++ b/02-explore-agentic-frameworks/code_samples/02-dotnet-agent-framework.cs
@@ -4,6 +4,7 @@
 #:package Microsoft.Agents.AI.OpenAI@1.*-*
 #:package Azure.AI.OpenAI@2.1.0
 #:package Azure.Identity@1.13.1
+#:package DotNetEnv@3.1.1
 
 using System.ComponentModel;
 
@@ -12,6 +13,12 @@ using Microsoft.Extensions.AI;
 
 using Azure.AI.OpenAI;
 using Azure.Identity;
+using OpenAI.Chat;
+
+using DotNetEnv;
+
+// Load environment variables
+Env.Load("./.env");
 
 // Tool Function: Random Destination Generator
 // This static method will be available to the agent as a callable tool
@@ -78,8 +85,8 @@ Always prioritize user preferences. If they mention a specific destination like 
 // Configure agent with name, detailed instructions, and available tools
 // This demonstrates the .NET agent creation pattern with full configuration
 AIAgent agent = azureClient
-    .GetOpenAIResponseClient(deployment)
-    .CreateAIAgent(
+    .GetChatClient(deployment)
+    .AsAIAgent(
         name: AGENT_NAME,
         instructions: AGENT_INSTRUCTIONS,
         tools: [AIFunctionFactory.Create(GetRandomDestination)]

--- a/02-explore-agentic-frameworks/code_samples/02-dotnet-agent-framework.cs
+++ b/02-explore-agentic-frameworks/code_samples/02-dotnet-agent-framework.cs
@@ -18,7 +18,7 @@ using OpenAI.Chat;
 using DotNetEnv;
 
 // Load environment variables
-Env.Load("../../../.env");
+Env.Load("../../.env");
 
 // Tool Function: Random Destination Generator
 // This static method will be available to the agent as a callable tool

--- a/02-explore-agentic-frameworks/code_samples/02-dotnet-agent-framework.cs
+++ b/02-explore-agentic-frameworks/code_samples/02-dotnet-agent-framework.cs
@@ -4,7 +4,6 @@
 #:package Microsoft.Agents.AI.OpenAI@1.*-*
 #:package Azure.AI.OpenAI@2.1.0
 #:package Azure.Identity@1.13.1
-#:package DotNetEnv@3.1.1
 
 using System.ComponentModel;
 
@@ -14,11 +13,6 @@ using Microsoft.Extensions.AI;
 using Azure.AI.OpenAI;
 using Azure.Identity;
 using OpenAI.Chat;
-
-using DotNetEnv;
-
-// Load environment variables
-Env.Load("../../.env");
 
 // Tool Function: Random Destination Generator
 // This static method will be available to the agent as a callable tool

--- a/02-explore-agentic-frameworks/code_samples/02-dotnet-agent-framework.cs
+++ b/02-explore-agentic-frameworks/code_samples/02-dotnet-agent-framework.cs
@@ -18,7 +18,7 @@ using OpenAI.Chat;
 using DotNetEnv;
 
 // Load environment variables
-Env.Load("./.env");
+Env.Load("../../../.env");
 
 // Tool Function: Random Destination Generator
 // This static method will be available to the agent as a callable tool

--- a/02-explore-agentic-frameworks/code_samples/02-dotnet-agent-framework.md
+++ b/02-explore-agentic-frameworks/code_samples/02-dotnet-agent-framework.md
@@ -179,8 +179,8 @@ Always prioritize user preferences. If they mention a specific destination like 
 // Configure agent with name, detailed instructions, and available tools
 // This demonstrates the .NET agent creation pattern with full configuration
 AIAgent agent = azureClient
-    .GetOpenAIResponseClient(deployment)
-    .CreateAIAgent(
+    .GetChatClient(deployment)
+    .AsAIAgent(
         name: AGENT_NAME,
         instructions: AGENT_INSTRUCTIONS,
         tools: [AIFunctionFactory.Create(GetRandomDestination)]

--- a/02-explore-agentic-frameworks/code_samples/02-dotnet-agent-framework.md
+++ b/02-explore-agentic-frameworks/code_samples/02-dotnet-agent-framework.md
@@ -40,7 +40,7 @@ This example explores the fundamental concepts of the Microsoft Agent Framework 
 
 - Natural language understanding and generation
 - Function calling and tool usage with C# attributes
-- Context-aware responses with conversation threads
+- Context-aware responses with conversation sessions
 - Extensible architecture with dependency injection patterns
 
 ## 📚 Framework Comparison
@@ -186,17 +186,17 @@ AIAgent agent = azureClient
         tools: [AIFunctionFactory.Create(GetRandomDestination)]
     );
 
-// Create New Conversation Thread for Context Management
-// Initialize a new conversation thread to maintain context across multiple interactions
-// Threads enable the agent to remember previous exchanges and maintain conversational state
+// Create New Session for Context Management.
+// Initialize a new conversation session to maintain context across multiple interactions
+// Sessions enable the agent to remember previous exchanges and maintain conversational state
 // This is essential for multi-turn conversations and contextual understanding
-AgentThread thread = agent.GetNewThread();
+AgentSession session = await agent.CreateSessionAsync();
 
 // Execute Agent: First Travel Planning Request
 // Run the agent with an initial request that will likely trigger the random destination tool
 // The agent will analyze the request, use the GetRandomDestination tool, and create an itinerary
-// Using the thread parameter maintains conversation context for subsequent interactions
-await foreach (var update in agent.RunStreamingAsync("Plan me a day trip", thread))
+// Using the session parameter maintains conversation context for subsequent interactions
+await foreach (var update in agent.RunStreamingAsync("Plan me a day trip", session))
 {
     await Task.Delay(10);
     Console.Write(update);
@@ -207,8 +207,8 @@ Console.WriteLine();
 // Execute Agent: Follow-up Request with Context Awareness
 // Demonstrate contextual conversation by referencing the previous response
 // The agent remembers the previous destination suggestion and will provide an alternative
-// This showcases the power of conversation threads and contextual understanding in .NET agents
-await foreach (var update in agent.RunStreamingAsync("I don't like that destination. Plan me another vacation.", thread))
+// This showcases the power of conversation sessions and contextual understanding in .NET agents
+await foreach (var update in agent.RunStreamingAsync("I don't like that destination. Plan me another vacation.", session))
 {
     await Task.Delay(10);
     Console.Write(update);
@@ -219,7 +219,7 @@ await foreach (var update in agent.RunStreamingAsync("I don't like that destinat
 
 1. **Agent Architecture**: The Microsoft Agent Framework provides a clean, type-safe approach to building AI agents in .NET
 2. **Tool Integration**: Functions decorated with `[Description]` attributes become available tools for the agent
-3. **Conversation Context**: Thread management enables multi-turn conversations with full context awareness
+3. **Conversation Context**: Session management enables multi-turn conversations with full context awareness
 4. **Configuration Management**: Environment variables and secure credential handling follow .NET best practices
 5. **Azure OpenAI Responses API**: The agent uses the Azure OpenAI Responses API through the Azure.AI.OpenAI SDK
 


### PR DESCRIPTION
**Summary**  
This PR updates the Lesson 02 .NET agent framework sample to improve compatibility with the latest APIs.

**Changes**

- Updated agent instantiation to use `GetChatClient` and `AsAIAgent`, replacing `GetOpenAIResponseClient` (`AsAIAgent` creates an AI agent from an `OpenAI.Chat.ChatClient`).
- Added necessary using directives for new functionality.
- Ensured sample runs correctly

Addresses Issue: #639

**Why**  

The previous sample referenced `GetOpenAIResponseClient`, which is not available in the current `AzureOpenAIClient SDK`. The correct approach is to use `OpenAI.Chat.ChatClient.GetChatClient` with `AsAIAgent`. This update aligns the sample with the latest stable APIs.

**Testing**

- Verified compilation and execution using .NET 10.0.301 SDK.
- Confirmed agent creation and session management work as expected with updated APIs.