### PR TITLE
fix(lesson-03): update agent creation 

### DIFF
--- a/03-agentic-design-patterns/code_samples/03-dotnet-agent-framework.cs
+++ b/03-agentic-design-patterns/code_samples/03-dotnet-agent-framework.cs
@@ -4,7 +4,6 @@
 #:package Microsoft.Agents.AI.OpenAI@1.*-*
 #:package Azure.AI.OpenAI@2.1.0
 #:package Azure.Identity@1.13.1
-#:package DotNetEnv@3.1.1
 
 using System.ComponentModel;
 
@@ -14,11 +13,6 @@ using Microsoft.Extensions.AI;
 using Azure.AI.OpenAI;
 using Azure.Identity;
 using OpenAI.Chat;
-
-using DotNetEnv;
-
-// Load environment variables
-Env.Load("../../.env");
 
 // ============================================================================
 // AGENTIC DESIGN PRINCIPLES DEMONSTRATION

--- a/03-agentic-design-patterns/code_samples/03-dotnet-agent-framework.cs
+++ b/03-agentic-design-patterns/code_samples/03-dotnet-agent-framework.cs
@@ -4,6 +4,7 @@
 #:package Microsoft.Agents.AI.OpenAI@1.*-*
 #:package Azure.AI.OpenAI@2.1.0
 #:package Azure.Identity@1.13.1
+#:package DotNetEnv@3.1.1
 
 using System.ComponentModel;
 
@@ -12,6 +13,12 @@ using Microsoft.Extensions.AI;
 
 using Azure.AI.OpenAI;
 using Azure.Identity;
+using OpenAI.Chat;
+
+using DotNetEnv;
+
+// Load environment variables
+Env.Load("../../.env");
 
 // ============================================================================
 // AGENTIC DESIGN PRINCIPLES DEMONSTRATION
@@ -111,8 +118,8 @@ What kind of trip would you like me to help you plan today?"
 
 // Create AI Agent with Design Principles
 AIAgent agent = azureClient
-    .GetOpenAIResponseClient(deployment)
-    .CreateAIAgent(
+    .GetChatClient(deployment)
+    .AsAIAgent(
         name: AGENT_NAME,
         instructions: AGENT_INSTRUCTIONS,
         tools: [
@@ -122,7 +129,7 @@ AIAgent agent = azureClient
     );
 
 // Create Conversation Session for Context Management
-await using var session = await agent.CreateSessionAsync();
+var session = await agent.CreateSessionAsync();
 
 // ============================================================================
 // DEMONSTRATION: Start with "Hello" to trigger the greeting (Issue #402 fix)

--- a/03-agentic-design-patterns/code_samples/03-dotnet-agent-framework.md
+++ b/03-agentic-design-patterns/code_samples/03-dotnet-agent-framework.md
@@ -244,24 +244,24 @@ Always prioritize user preferences. If they mention a specific destination like 
 // Configure agent with name, detailed instructions, and available tools
 // This demonstrates the .NET agent creation pattern with full configuration
 AIAgent agent = azureClient
-    .GetOpenAIResponseClient(deployment)
-    .CreateAIAgent(
+    .GetChatClient(deployment)
+    .AsAIAgent(
         name: AGENT_NAME,
         instructions: AGENT_INSTRUCTIONS,
         tools: [AIFunctionFactory.Create(GetRandomDestination)]
     );
 
-// Create New Conversation Thread for Context Management
-// Initialize a new conversation thread to maintain context across multiple interactions
-// Threads enable the agent to remember previous exchanges and maintain conversational state
+// Create New Conversation Session for Context Management
+// Initialize a new conversation session to maintain context across multiple interactions
+// Sessions enable the agent to remember previous exchanges and maintain conversational state
 // This is essential for multi-turn conversations and contextual understanding
-AgentThread thread = agent.GetNewThread();
+var session = await agent.CreateSessionAsync();
 
 // Execute Agent: First Travel Planning Request
 // Run the agent with an initial request that will likely trigger the random destination tool
 // The agent will analyze the request, use the GetRandomDestination tool, and create an itinerary
-// Using the thread parameter maintains conversation context for subsequent interactions
-await foreach (var update in agent.RunStreamingAsync("Plan me a day trip", thread))
+// Using the session parameter maintains conversation context for subsequent interactions
+await foreach (var update in agent.RunStreamingAsync("Plan me a day trip", session))
 {
     await Task.Delay(10);
     Console.Write(update);
@@ -272,8 +272,8 @@ Console.WriteLine();
 // Execute Agent: Follow-up Request with Context Awareness
 // Demonstrate contextual conversation by referencing the previous response
 // The agent remembers the previous destination suggestion and will provide an alternative
-// This showcases the power of conversation threads and contextual understanding in .NET agents
-await foreach (var update in agent.RunStreamingAsync("I don't like that destination. Plan me another vacation.", thread))
+// This showcases the power of conversation sessions and contextual understanding in .NET agents
+await foreach (var update in agent.RunStreamingAsync("I don't like that destination. Plan me another vacation.", session))
 {
     await Task.Delay(10);
     Console.Write(update);


### PR DESCRIPTION
**Summary**  
This PR updates the Lesson 03 .NET agent framework sample to improve compatibility with the latest APIs.

**Changes**

- Updated agent instantiation to use `GetChatClient` and `AsAIAgent`, replacing `GetOpenAIResponseClient` (`AsAIAgent` creates an AI agent from an `OpenAI.Chat.ChatClient`).
- Added necessary using directives for new functionality.
- Ensured sample runs correctly

Addresses Issue: #639

**Why**  

The previous sample referenced `GetOpenAIResponseClient`, which is not available in the current `AzureOpenAIClient SDK`. The correct approach is to use `OpenAI.Chat.ChatClient.GetChatClient` with `AsAIAgent`. This update aligns the sample with the latest stable APIs.

**Testing**

- Verified compilation and execution using .NET 10.0.301 SDK.
- Confirmed agent creation and session management work as expected with updated APIs.