### PR TITLE
fix(lesson 07): update to new AI agent APIs and bump dependencies for C# sample

### DIFF
--- a/07-planning-design/code_samples/07-dotnet-agent-framework.cs
+++ b/07-planning-design/code_samples/07-dotnet-agent-framework.cs
@@ -1,10 +1,11 @@
 #!/usr/bin/dotnet run
-#:package Microsoft.Extensions.AI@9.9.1
-#:package Microsoft.Agents.AI.OpenAI@1.0.0-preview.251001.3
-#:package Microsoft.Agents.AI@1.0.0-preview.251001.3
+#:package Microsoft.Extensions.AI@10.*
+#:package Microsoft.Agents.AI.OpenAI@1.*-*
 #:package Azure.AI.OpenAI@2.1.0
 #:package Azure.Identity@1.13.1
 #:package DotNetEnv@3.1.1
+
+#:property JsonSerializerIsReflectionEnabledByDefault=true
 
 using System;
 using System.Text.Json;
@@ -14,9 +15,10 @@ using Microsoft.Agents.AI;
 using Azure.AI.OpenAI;
 using Azure.Identity;
 using DotNetEnv;
+using OpenAI.Chat;
 
 // Load environment variables from .env file
-Env.Load("../../../.env");
+Env.Load("../../.env");
 
 // Azure OpenAI with the Responses API (stable v1 endpoint). Sign in with `az login`.
 var azureEndpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")
@@ -39,8 +41,10 @@ const string AGENT_INSTRUCTIONS = @"You are an planner agent.
     - DefaultAgent: For handling general request";
 
 // Configure agent with structured output
-ChatClientAgentOptions agentOptions = new(name: AGENT_NAME, instructions: AGENT_INSTRUCTIONS)
+ChatClientAgentOptions agentOptions = new()
 {
+    Name = AGENT_NAME,
+    Description = AGENT_INSTRUCTIONS,
     ChatOptions = new()
     {
         ResponseFormat = ChatResponseFormatJson.ForJsonSchema(
@@ -52,8 +56,8 @@ ChatClientAgentOptions agentOptions = new(name: AGENT_NAME, instructions: AGENT_
 
 // Create AI agent
 AIAgent agent = azureClient
-    .GetOpenAIResponseClient(deployment)
-    .CreateAIAgent(agentOptions);
+    .GetChatClient(deployment)
+    .AsAIAgent(agentOptions);
 
 // Execute planning request
 Console.WriteLine(await agent.RunAsync("Create a travel plan for a family of 4, with 2 kids, from Singapore to Melbourne"));


### PR DESCRIPTION
**Summary**  

This PR updates the lesson 07 .NET agent framework sample to improve compatibility with the latest APIs


**Changes**

- Bumped `Microsoft.Extensions.AI to 10.*` and `Microsoft.Agents.AI.OpenAI to 1.*-*`.
- Added `#:property JsonSerializerIsReflectionEnabledByDefault=true` to support structured output in file‑based apps.
- Updated agent instantiation to use `GetChatClient` and `AsAIAgent`, replacing `GetOpenAIResponseClient` (`AsAIAgent` creates an AI agent from an `OpenAI.Chat.ChatClient`).
- Adjusted `ChatClientAgentOptions` to use `Name` and `Description` properties.
- Added necessary using directives (`OpenAI.Chat`) for new functionality
- Ensured sample runs correctly with `.env` configuration

Addresses: #639


**Why**  

The previous sample referenced `GetOpenAIResponseClient`, which is not available in the current `AzureOpenAIClient` SDK. The correct approach is to use `OpenAI.Chat.ChatClient.GetChatClient` with `AsAIAgent`. This update aligns the sample with the latest stable APIs, improves developer experience.


**Testing**

- Verified compilation and execution using `.NET 10.0.301` SDK.
- Confirmed environment variables load correctly from .env.
- Confirmed agent creation and structured output (`TravelPlan`) work as expected with updated APIs.
