### PR TITLE
fix(lesson-08): update multi-agent sample to use GetChatClient and updated obsolete event types

### DIFF
--- a/08-multi-agent/code_samples/08-dotnet-agent-framework.cs
+++ b/08-multi-agent/code_samples/08-dotnet-agent-framework.cs
@@ -35,7 +35,7 @@ var azureClient = new AzureOpenAIClient(new Uri(azureEndpoint), new AzureCliCred
 // Define agent roles and instructions
 const string REVIEWER_NAME = "Concierge";
 const string REVIEWER_INSTRUCTIONS = @"""
-    You are an are hotel concierge who has opinions about providing the most local and authentic experiences for travelers.
+    You are a hotel concierge who has opinions about providing the most local and authentic experiences for travelers.
     The goal is to determine if the front desk travel agent has recommended the best non-touristy experience for a traveler.
     If so, state that it is approved.
     If not, provide insight on how to refine the recommendation without using a specific example. 

--- a/08-multi-agent/code_samples/08-dotnet-agent-framework.cs
+++ b/08-multi-agent/code_samples/08-dotnet-agent-framework.cs
@@ -1,14 +1,14 @@
 #!/usr/bin/dotnet run
-#:package Microsoft.Extensions.AI.Abstractions@9.9.1
-#:package Azure.AI.Agents.Persistent@1.2.0-beta.4
+#:package Microsoft.Extensions.AI.Abstractions@10.*
+#:package Azure.AI.Agents.Persistent@1.2.0-beta.10
 #:package Azure.AI.OpenAI@2.1.0
 #:package Azure.Identity@1.15.0
 #:package System.Linq.Async@6.0.3
-#:package Microsoft.Extensions.AI@9.9.1
+#:package Microsoft.Extensions.AI@10.*
 #:package DotNetEnv@3.1.1
-#:package OpenTelemetry.Api@1.12.0
-#:package Microsoft.Agents.AI.Workflows@1.0.0-preview.251001.3
-#:package Microsoft.Agents.AI.OpenAI@1.0.0-preview.251001.2
+#:package OpenTelemetry.Api@1.*
+#:package Microsoft.Agents.AI.Workflows@1.*
+#:package Microsoft.Agents.AI.OpenAI@1.*-*
 
 using System;
 using System.Text.Json;
@@ -18,10 +18,12 @@ using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Workflows;
 using Azure.AI.OpenAI;
 using Azure.Identity;
+using ChatMessage = Microsoft.Extensions.AI.ChatMessage;
+using OpenAI.Chat;
 using DotNetEnv;
 
 // Load environment variables
-Env.Load("../../../.env");
+Env.Load("../../.env");
 
 // Azure OpenAI with the Responses API (stable v1 endpoint). Sign in with `az login`.
 var azureEndpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")
@@ -50,14 +52,24 @@ const string FRONTDESK_INSTRUCTIONS = @"""
     """;
 
 // Create agent options
-ChatClientAgentOptions frontdeskAgentOptions = new(name: FRONTDESK_NAME, instructions: FRONTDESK_INSTRUCTIONS);
-ChatClientAgentOptions reviewerAgentOptions = new(name: REVIEWER_NAME, instructions: REVIEWER_INSTRUCTIONS);
+ChatClientAgentOptions frontdeskAgentOptions = new()
+{
+    Name = FRONTDESK_NAME,
+    Description = FRONTDESK_INSTRUCTIONS,
+};
+ChatClientAgentOptions reviewerAgentOptions = new()
+{
+    Name = REVIEWER_NAME, 
+    Description = REVIEWER_INSTRUCTIONS
+};
 
 // Create agents
-AIAgent reviewerAgent = azureClient.GetOpenAIResponseClient(deployment).CreateAIAgent(
-    reviewerAgentOptions);
-AIAgent frontdeskAgent = azureClient.GetOpenAIResponseClient(deployment).CreateAIAgent(
-    frontdeskAgentOptions);
+AIAgent reviewerAgent = azureClient
+    .GetChatClient(deployment)
+    .AsAIAgent(reviewerAgentOptions);
+AIAgent frontdeskAgent = azureClient
+    .GetChatClient(deployment)
+    .AsAIAgent(frontdeskAgentOptions);
 
 // Build workflow with agent coordination
 var workflow = new WorkflowBuilder(frontdeskAgent)
@@ -65,7 +77,7 @@ var workflow = new WorkflowBuilder(frontdeskAgent)
             .Build();
 
 // Execute workflow with streaming
-StreamingRun run = await InProcessExecution.StreamAsync(workflow, new ChatMessage(ChatRole.User, "I would like to go to Paris."));
+StreamingRun run = await InProcessExecution.RunStreamingAsync(workflow, new ChatMessage(ChatRole.User, "I would like to go to Paris."));
 
 await run.TrySendMessageAsync(new TurnToken(emitEvents: true));
 
@@ -74,7 +86,7 @@ string strResult = "";
 // Process streaming events
 await foreach (WorkflowEvent evt in run.WatchStreamAsync().ConfigureAwait(false))
 {
-    if (evt is AgentRunUpdateEvent executorComplete)
+    if (evt is AgentResponseUpdateEvent executorComplete)
     {
         strResult += executorComplete.Data;
         Console.WriteLine($"{executorComplete.ExecutorId}: {executorComplete.Data}");

--- a/08-multi-agent/code_samples/08-dotnet-agent-framework.md
+++ b/08-multi-agent/code_samples/08-dotnet-agent-framework.md
@@ -19,13 +19,16 @@ This notebook demonstrates how to build sophisticated enterprise-grade multi-age
 
 **Required NuGet Packages:**
 ```xml
-<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.9.0" />
-<PackageReference Include="Azure.AI.Agents.Persistent" Version="1.2.0-beta.4" />
+<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.*" />
+<PackageReference Include="Azure.AI.Agents.Persistent" Version="1.2.0-beta.10" />
 <PackageReference Include="Azure.Identity" Version="1.15.0" />
 <PackageReference Include="System.Linq.Async" Version="6.0.3" />
-<PackageReference Include="Microsoft.Extensions.AI" Version="9.8.0" />
+<PackageReference Include="Microsoft.Extensions.AI" Version="10.*" />
 <PackageReference Include="DotNetEnv" Version="3.1.1" />
-<PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.9.0-preview.1.25458.4" />
+<PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.*" />
+<PackageReference Include="OpenTelemetry.Api" Version="1.*" />
+<PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.*" />
+<PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.*-*" />
 ```
 
 ## Code Sample

--- a/08-multi-agent/code_samples/workflows-agent-framework/README.md
+++ b/08-multi-agent/code_samples/workflows-agent-framework/README.md
@@ -63,7 +63,7 @@ In the Python example, we first define and create the two agents, each with spec
 # Define agent roles and instructions
 REVIEWER_NAME = "Concierge"
 REVIEWER_INSTRUCTIONS = """
-    You are an are hotel concierge who has opinions about providing the most local and authentic experiences for travelers...
+    You are a hotel concierge who has opinions about providing the most local and authentic experiences for travelers...
     """
 
 FRONTDESK_NAME = "FrontDesk"
@@ -112,7 +112,7 @@ The .NET implementation follows a very similar logic. First, constants are defin
 
 const string ReviewerAgentName = "Concierge";
 const string ReviewerAgentInstructions = @"
-    You are an are hotel concierge who has opinions about providing the most local and authentic experiences for travelers...";
+    You are a hotel concierge who has opinions about providing the most local and authentic experiences for travelers...";
 
 const string FrontDeskAgentName = "FrontDesk";
 const string FrontDeskAgentInstructions = @"""
@@ -125,9 +125,9 @@ The agents are created using an `AzureOpenAIClient` (Responses API), and then th
 // 01.dotnet-agent-framework-workflow-ghmodel-basic.ipynb
 
 // Create AIAgent instances
-AIAgent reviewerAgent = azureClient.GetOpenAIResponseClient(deployment).CreateAIAgent(
+AIAgent reviewerAgent = azureClient.GetChatClient(deployment).AsAIAgent(
     name:ReviewerAgentName,instructions:ReviewerAgentInstructions);
-AIAgent frontDeskAgent  = azureClient.GetOpenAIResponseClient(deployment).CreateAIAgent(
+AIAgent frontDeskAgent  = azureClient.GetChatClient(deployment).AsAIAgent(
     name:FrontDeskAgentName,instructions:FrontDeskAgentInstructions);
 
 // Build the workflow
@@ -194,9 +194,9 @@ The .NET example mirrors the Python version. Three agents (`salesagent`, `pricea
 // 02.dotnet-agent-framework-workflow-ghmodel-sequential.ipynb
 
 // Create agent instances
-AIAgent salesagent = azureClient.GetOpenAIResponseClient(deployment).CreateAIAgent(...);
-AIAgent priceagent  = azureClient.GetOpenAIResponseClient(deployment).CreateAIAgent(...);
-AIAgent quoteagent = azureClient.GetOpenAIResponseClient(deployment).CreateAIAgent(...);
+AIAgent salesagent = azureClient.GetChatClient(deployment).AsAIAgent(...);
+AIAgent priceagent  = azureClient.GetChatClient(deployment).AsAIAgent(...);
+AIAgent quoteagent = azureClient.GetChatClient(deployment).AsAIAgent(...);
 
 // Build the workflow by adding edges sequentially
 var workflow = new WorkflowBuilder(salesagent)
@@ -205,7 +205,7 @@ var workflow = new WorkflowBuilder(salesagent)
             .Build();
 ```
 
-The user's message is constructed with both the image data (as bytes) and the text prompt. The `InProcessExecution.StreamAsync` method initiates the workflow, and the final output is captured from the stream.
+The user's message is constructed with both the image data (as bytes) and the text prompt. The `InProcessExecution.RunStreamingAsync` method initiates the workflow, and the final output is captured from the stream.
 
 ### Case 3: Concurrent Workflow
 


### PR DESCRIPTION
**Summary**  
This PR updates the Lesson 08 .NET multi‑agent framework sample to align with the latest APIs and event types.
Addresses: #639

**Changes**
- Bumped dependencies to the latest stable/preview versions (`Microsoft.Extensions.AI@10.*, Azure.AI.Agents.Persistent@1.2.0-beta.10, Microsoft.Agents.AI.Workflows@1.*`, etc.).
- Replaced `GetOpenAIResponseClient` with `GetChatClient` and `AsAIAgent` (`AsAIAgent` creates an AI agent from an `OpenAI.Chat.ChatClient`).
- Updated `ChatClientAgentOptions` to use `Name` and `Description`.
- Changed workflow execution from `StreamAsync` → `RunStreamingAsync`.
- Replaced `AgentRunUpdateEvent` with `AgentResponseUpdateEvent`.

**Why**  
Older APIs (`GetOpenAIResponseClient`, `AgentRunUpdateEvent`) are no longer available. This update ensures the sample compiles and runs correctly with the latest SDKs.

**Testing**
- Verified build and run with .NET 10.0.301 SDK
- Validated multi‑agent workflow executes successfully with streaming updates.