### PR TITLE
fix(docs-lesson04-dotnet): Update obsolete code for agent creation and context management

### DIFF
--- a/04-tool-use/code_samples/04-dotnet-agent-framework.md
+++ b/04-tool-use/code_samples/04-dotnet-agent-framework.md
@@ -211,7 +211,7 @@ AIAgent agent = azureClient
 // Initialize a new conversation session to maintain context across multiple interactions
 // Sessions enable the agent to remember previous exchanges and maintain conversational state
 // This is essential for multi-turn conversations and contextual understanding
-AgentSession session = await agent.CreateSessionAsync();
+await using var session = await agent.CreateSessionAsync();
 
 // Execute Agent: First Travel Planning Request
 // Run the agent with an initial request that will likely trigger the random destination tool

--- a/04-tool-use/code_samples/04-dotnet-agent-framework.md
+++ b/04-tool-use/code_samples/04-dotnet-agent-framework.md
@@ -200,24 +200,24 @@ Always prioritize user preferences. If they mention a specific destination like 
 // Configure agent with name, detailed instructions, and available tools
 // This demonstrates the .NET agent creation pattern with full configuration
 AIAgent agent = azureClient
-    .GetOpenAIResponseClient(deployment)
-    .CreateAIAgent(
+    .GetChatClient(deployment)
+    .AsAIAgent(
         name: AGENT_NAME,
         instructions: AGENT_INSTRUCTIONS,
         tools: [AIFunctionFactory.Create(GetRandomDestination)]
     );
 
-// Create New Conversation Thread for Context Management
-// Initialize a new conversation thread to maintain context across multiple interactions
-// Threads enable the agent to remember previous exchanges and maintain conversational state
+// Create New Conversation Session for Context Management
+// Initialize a new conversation session to maintain context across multiple interactions
+// Sessions enable the agent to remember previous exchanges and maintain conversational state
 // This is essential for multi-turn conversations and contextual understanding
-AgentThread thread = agent.GetNewThread();
+AgentSession session = await agent.CreateSessionAsync();
 
 // Execute Agent: First Travel Planning Request
 // Run the agent with an initial request that will likely trigger the random destination tool
 // The agent will analyze the request, use the GetRandomDestination tool, and create an itinerary
-// Using the thread parameter maintains conversation context for subsequent interactions
-await foreach (var update in agent.RunStreamingAsync("Plan me a day trip", thread))
+// Using the session parameter maintains conversation context for subsequent interactions
+await foreach (var update in agent.RunStreamingAsync("Plan me a day trip", session))
 {
     await Task.Delay(10);
     Console.Write(update);
@@ -228,8 +228,8 @@ Console.WriteLine();
 // Execute Agent: Follow-up Request with Context Awareness
 // Demonstrate contextual conversation by referencing the previous response
 // The agent remembers the previous destination suggestion and will provide an alternative
-// This showcases the power of conversation threads and contextual understanding in .NET agents
-await foreach (var update in agent.RunStreamingAsync("I don't like that destination. Plan me another vacation.", thread))
+// This showcases the power of conversation sessions and contextual understanding in .NET agents
+await foreach (var update in agent.RunStreamingAsync("I don't like that destination. Plan me another vacation.", session))
 {
     await Task.Delay(10);
     Console.Write(update);


### PR DESCRIPTION
**Summary**  
This PR refactors the .NET agent framework sample to provide up-to-date code for conversation context management and agent creation.

Addresses: #639

**Changes**
- Replaced `AgentThread` with `AgentSession` for managing conversation context.
- Updated agent creation to use `GetChatClient().AsAIAgent(`) instead of older APIs (`AsAIAgent` creates an AI agent from an `OpenAI.Chat.ChatClient`).
- Refactored streaming interactions to session‑based context management.

**Why**  
The previous implementation relied on `AgentThread`, which is deprecated. `AgentSession` provides a more robust and consistent model for managing agent conversations. This refactor aligns the sample with current SDK guidance and improves maintainability.

**Testing**

- Verified compilation and execution with .NET 10.0.301 SDK.
- Confirmed session creation and disposal work correctly.

