### PR TITLE
fix(docs-lesson07-dotnet): Update obsolete code samples

### DIFF
--- a/07-planning-design/code_samples/07-dotnet-agent-framework.md
+++ b/07-planning-design/code_samples/07-dotnet-agent-framework.md
@@ -15,6 +15,7 @@ This notebook demonstrates enterprise-grade planning and design patterns for bui
 **Required Dependencies:**
 ```xml
 <PackageReference Include="Microsoft.Extensions.AI" Version="10.*" />
+<PackageReference Include="Microsoft.Agents.AI" Version="1.*-*" />
 <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.*-*" />
 <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
 <PackageReference Include="Azure.Identity" Version="1.13.1" />

--- a/07-planning-design/code_samples/07-dotnet-agent-framework.md
+++ b/07-planning-design/code_samples/07-dotnet-agent-framework.md
@@ -14,7 +14,8 @@ This notebook demonstrates enterprise-grade planning and design patterns for bui
 
 **Required Dependencies:**
 ```xml
-<PackageReference Include="Microsoft.Extensions.AI" Version="9.9.0" />
+<PackageReference Include="Microsoft.Extensions.AI" Version="10.*" />
+<PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.*-*" />
 <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
 <PackageReference Include="Azure.Identity" Version="1.13.1" />
 <PackageReference Include="DotNetEnv" Version="3.1.1" />
@@ -85,8 +86,10 @@ public class TravelPlan
 The agent is configured to return responses matching the TravelPlan schema:
 
 ```csharp
-ChatClientAgentOptions agentOptions = new(name: AGENT_NAME, instructions: AGENT_INSTRUCTIONS)
+ChatClientAgentOptions agentOptions = new()
 {
+    Name = AGENT_NAME,
+    Description = AGENT_INSTRUCTIONS,
     ChatOptions = new()
     {
         ResponseFormat = ChatResponseFormatJson.ForJsonSchema(


### PR DESCRIPTION
**Summary**  
This PR updates the Lesson 07 documentation code sample to align with the latest .NET agent framework APIs and package versions.

Addresses: #639
PR for that updates 07-dotnet-agent-framework.cs: #644

**Changes**

- Bumped dependencies to current versions (`Microsoft.Extensions.AI@10.*`, `Microsoft.Agents.AI.OpenAI@1.*-*`, `Azure.AI.OpenAI@2.1.0`, etc.).
- Updated agent creation to use `GetChatClient().AsAIAgent()` instead of `GetOpenAIResponseClient` (`AsAIAgent` creates an AI agent from an `OpenAI.Chat.ChatClient`).
- Refactored `ChatClientAgentOptions` initialization to use `Name` and `Description` properties.

**Why**  
The previous docs referenced deprecated APIs and older package versions. This update ensures the sample compiles and runs correctly with the latest SDKs.

**Testing**
- Verified compilation and execution with `.NET 10.0.301 SDK`.
- Validated agent creation and structured output (`TravelPlan`) work as expected.