### PR TITLE
docs: add browser agent safety guardrails

### DIFF
--- a/15-browser-use/README.md
+++ b/15-browser-use/README.md
@@ -88,6 +88,20 @@ This approach keeps the flexible, vision-based reasoning that Browser-Use is goo
 6. Expect websites to change and design fallback strategies for pop-ups and layout shifts.
 7. Blend agent and actor patterns to get both flexibility and precision.
 
+### Safety Guardrails for Browser Agents
+
+Browser agents operate on live websites, so they need tighter boundaries than a script that only calls a known API. Before moving from a notebook demo to a real workflow, define the controls around what the agent can see, click, and submit.
+
+1. **Scope the browsing environment.** Run the agent in a dedicated browser profile or sandbox, and limit it to the domains required for the task.
+2. **Separate observation from action.** Let the agent search, read, and extract data first; require an explicit approval step before it submits forms, sends messages, books travel, makes purchases, deletes records, or changes account settings.
+3. **Keep secrets out of prompts and traces.** Do not place passwords, payment details, session cookies, or raw personal data in the model context. Let the user take over for authentication and redact sensitive fields from logs.
+4. **Treat page content as untrusted input.** A website can contain instructions that are meant for the agent, not the user. The agent should ignore page text that asks it to change its goal, reveal data, disable safeguards, or visit unrelated sites.
+5. **Use deterministic checks around risky steps.** Verify the current URL, page title, selected item, price, recipient, and action summary with code before asking the user to approve the final step.
+6. **Set budgets and stop conditions.** Bound the number of actions, retries, tabs, and minutes the agent can use. Stop when the page state is ambiguous instead of continuing to click.
+7. **Record useful evidence, not everything.** Keep action summaries, timestamps, URLs, selected element descriptions, and screenshot references so failures can be reviewed without storing unnecessary sensitive page content.
+
+In the Airbnb sample, the safe default is to search listings and extract prices. Signing in, contacting a host, or completing a booking should be a separate user-approved action.
+
 ### Real-World Applications
 
 - Travel booking and price monitoring


### PR DESCRIPTION
## Summary

Adds a short safety guardrails section to Lesson 15 for browser-based computer use agents.

The new section covers:
- scoping browser sessions and allowed domains
- separating observation from actions that require approval
- keeping credentials and sensitive data out of prompts and traces
- treating page content as untrusted input
- using deterministic checks before risky steps
- setting action budgets and stop conditions
- keeping reviewable evidence without over-logging page content

It also clarifies that the Airbnb sample should stay focused on searching and extracting prices unless a user explicitly approves follow-up actions such as signing in, contacting a host, or completing a booking.

## Validation

- Ran `git diff --check`
- Docs-only change