### PR TITLE
continue on error when assigned reviewer is not part of the repo

### DIFF
--- a/.github/workflows/welcome-issue.yml
+++ b/.github/workflows/welcome-issue.yml
@@ -28,6 +28,7 @@ jobs:
               body: `👋 Thanks for contributing @${ issueAuthor }! We will review the issue and get back to you soon.`
             })
       - name: Auto-assign issue
+        continue-on-error: true
         uses: pozil/auto-assign-issue@v2
         with:
           repo-token:  ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/welcome-pr.yml
+++ b/.github/workflows/welcome-pr.yml
@@ -28,6 +28,7 @@ jobs:
               body: `👋 Thanks for contributing @${ issueAuthor }! We will review the pull request and get back to you soon.`
             })
       - name: Auto-assign issue
+        continue-on-error: true
         uses: pozil/auto-assign-issue@v2
         with:
           repo-token:  ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This doesn't fail the job when the assigned reviewer is not part of the repo and marks it with warning instead when it fails.
It can work till you change the `assignees` field to someone who has access to the repo maybe to `leestott` but if you don't want that at all I suggest deleting the job from the workflows.

Delete from `- name: Auto-assign issue` to end of file.