### PR TITLE
docs: add Novita AI as alternative OpenAI-compatible provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,7 @@ MINIMAX_MODEL_ID="MiniMax-M3"
 
 # Novita AI (Alternative OpenAI-compatible provider)
 # Novita AI offers open-source and frontier LLMs (DeepSeek, Llama, Qwen, and more) via an OpenAI-compatible API.
+# NOTE: Current samples do not automatically consume NOVITA_* variables; pass these values explicitly when constructing OpenAIChatClient.
 # Get your API key from https://novita.ai/settings/key-management
 NOVITA_API_KEY="..."
 NOVITA_BASE_URL="https://api.novita.ai/openai/v1"

--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,10 @@ BING_CONNECTION_ID="..."
 MINIMAX_API_KEY="..."
 MINIMAX_BASE_URL="https://api.minimax.io/v1"
 MINIMAX_MODEL_ID="MiniMax-M3"
+
+# Novita AI (Alternative OpenAI-compatible provider)
+# Novita AI offers open-source and frontier LLMs (DeepSeek, Llama, Qwen, and more) via an OpenAI-compatible API.
+# Get your API key from https://novita.ai/settings/key-management
+NOVITA_API_KEY="..."
+NOVITA_BASE_URL="https://api.novita.ai/openai/v1"
+NOVITA_MODEL_ID="moonshotai/kimi-k3"

--- a/00-course-setup/README.md
+++ b/00-course-setup/README.md
@@ -264,6 +264,22 @@ Add these variables to your `.env` file:
 
 The code samples that use `OpenAIChatClient` (e.g., Lesson 14 hotel booking workflow) will automatically detect and use your MiniMax configuration when `MINIMAX_API_KEY` is set.
 
+## Alternative Provider: Novita AI (OpenAI-Compatible)
+
+[Novita AI](https://novita.ai/llm-api) provides an OpenAI-compatible API for open-source and frontier LLMs (DeepSeek, Llama, Qwen, and more). Since the Microsoft Agent Framework's `OpenAIChatClient` works with any OpenAI-compatible endpoint, you can use Novita AI as a drop-in alternative to Azure OpenAI or OpenAI.
+
+Add these variables to your `.env` file:
+
+| Variable | Where to find it |
+|----------|-----------------|
+| `NOVITA_API_KEY` | [Novita AI Dashboard](https://novita.ai/settings/key-management) → API Keys |
+| `NOVITA_BASE_URL` | Use `https://api.novita.ai/openai/v1` (default value) |
+| `NOVITA_MODEL_ID` | Model name to use (e.g., `moonshotai/kimi-k3`) |
+
+**Example models**: `moonshotai/kimi-k3`, `zai-org/glm-5.2`, `deepseek/deepseek-v4-flash-0731`. Novita AI also hosts many other open-source model families (Llama, Qwen, GLM, and more) — check the [Novita AI model library](https://novita.ai/llm-api) for the current list of available models and their model IDs.
+
+The current samples do not automatically consume `NOVITA_*` variables. To use Novita AI, pass these values explicitly when constructing `OpenAIChatClient` in the sample you are running.
+
 ## Alternative Provider: Foundry Local (Run Models On-Device)
 
 [Foundry Local](https://foundrylocal.ai) is a lightweight runtime that downloads, manages, and serves language models **entirely on your own machine** through an OpenAI-compatible API — no cloud, no Azure subscription, and no API keys. It's a great option for offline development, experimenting without incurring cloud costs, or keeping data on-device.


### PR DESCRIPTION
## Summary

Adds documentation for Novita AI as an OpenAI-compatible provider in the course setup materials, alongside the existing MiniMax guidance, with matching example environment variables.

## Fixes from the previous PR

- Uses the correct Novita OpenAI-compatible base URL: `https://api.novita.ai/openai/v1`.
- Clarifies that the current samples do not automatically consume `NOVITA_*` variables; users must pass the values explicitly when constructing `OpenAIChatClient`.

## Testing

Documentation-only change. Verified the Novita URL appears consistently in `.env.example` and `00-course-setup/README.md`, and ran `git diff --check`.

Supersedes the closed [#709](https://github.com/microsoft/ai-agents-for-beginners/pull/709), which could not be reopened after its head branch was force-pushed/recreated.
