### PR TITLE
docs: add OrcaRouter as alternative OpenAI-compatible provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,11 @@ BING_CONNECTION_ID="..."
 MINIMAX_API_KEY="..."
 MINIMAX_BASE_URL="https://api.minimax.io/v1"
 MINIMAX_MODEL_ID="MiniMax-M3"
+
+# OrcaRouter (Alternative OpenAI-compatible provider)
+# OrcaRouter is an AI gateway that routes to frontier models (Claude, GPT, Gemini,
+# DeepSeek, and more) through a single OpenAI-compatible endpoint.
+# Get your API key from https://www.orcarouter.ai
+ORCAROUTER_API_KEY="..."
+ORCAROUTER_BASE_URL="https://api.orcarouter.ai/v1"
+ORCAROUTER_MODEL_ID="orcarouter/auto"

--- a/00-course-setup/README.md
+++ b/00-course-setup/README.md
@@ -264,6 +264,22 @@ Add these variables to your `.env` file:
 
 The code samples that use `OpenAIChatClient` (e.g., Lesson 14 hotel booking workflow) will automatically detect and use your MiniMax configuration when `MINIMAX_API_KEY` is set.
 
+## Alternative Provider: OrcaRouter (OpenAI-Compatible)
+
+[OrcaRouter](https://www.orcarouter.ai) is an AI gateway that routes requests to frontier models (Claude, GPT, Gemini, DeepSeek, and more) through a single OpenAI-compatible endpoint. Since the Microsoft Agent Framework's `OpenAIChatClient` works with any OpenAI-compatible endpoint, you can use OrcaRouter as a drop-in alternative to Azure OpenAI or OpenAI.
+
+Add these variables to your `.env` file:
+
+| Variable | Where to find it |
+|----------|-----------------|
+| `ORCAROUTER_API_KEY` | [OrcaRouter Console](https://www.orcarouter.ai) → API Keys |
+| `ORCAROUTER_BASE_URL` | Use `https://api.orcarouter.ai/v1` (default value) |
+| `ORCAROUTER_MODEL_ID` | Model name to use (e.g., `orcarouter/auto`) |
+
+**Example models**: `orcarouter/auto` (smart routing), `anthropic/claude-sonnet-4.6`, `openai/gpt-5.5`, `google/gemini-2.5-flash`, `deepseek/deepseek-v4-flash-0731`. Model names and availability can change over time, and access to a given model may depend on your account or region — check the [OrcaRouter model directory](https://www.orcarouter.ai) for the current list.
+
+The current samples do not automatically consume `ORCAROUTER_*` variables. To use OrcaRouter, pass these values explicitly when constructing `OpenAIChatClient` in the sample you are running.
+
 ## Alternative Provider: Foundry Local (Run Models On-Device)
 
 [Foundry Local](https://foundrylocal.ai) is a lightweight runtime that downloads, manages, and serves language models **entirely on your own machine** through an OpenAI-compatible API — no cloud, no Azure subscription, and no API keys. It's a great option for offline development, experimenting without incurring cloud costs, or keeping data on-device.


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a model provider. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also provides gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

## What this changes

- `.env.example`: adds an `ORCAROUTER_*` block alongside the existing MiniMax block
- `00-course-setup/README.md`: adds an "Alternative Provider: OrcaRouter (OpenAI-Compatible)" section alongside the existing MiniMax, Novita AI and Foundry Local sections

## Why a named provider rather than the OpenAI-compatible escape hatch

The course already lists named alternative providers (MiniMax, Novita AI, Foundry Local) that expose OpenAI-compatible endpoints, and it notes that `OpenAIChatClient` works with any OpenAI-compatible API. This mirrors that same shape for OrcaRouter, so the config reference and setup docs stay consistent for learners who want a single key that routes to many model families.

## How to use it

1. Get an API key at https://www.orcarouter.ai (keys start with `sk-orca-`).
2. Set `ORCAROUTER_API_KEY` in your `.env` (optionally `ORCAROUTER_BASE_URL`, `ORCAROUTER_MODEL_ID`).
3. Pick a model id such as `orcarouter/auto`, `anthropic/claude-sonnet-4.6` or `openai/gpt-5.5`. The full catalog is available from the OrcaRouter model directory.

## Verification

- Live API against `https://api.orcarouter.ai/v1/chat/completions`:
  - `orcarouter/auto` returns 200 (routes to an upstream reasoning model)
  - `anthropic/claude-sonnet-4.6` returns 200
  - Invalid `sk-orca-` key returns 401
- All model ids listed in the docs (`orcarouter/auto`, `anthropic/claude-sonnet-4.6`, `openai/gpt-5.5`, `google/gemini-2.5-flash`, `deepseek/deepseek-v4-flash-0731`) are present in the OrcaRouter model catalog.
