### PR TITLE
[Fix] Align Lesson 18 signature scope with draft revision 02

### DIFF
--- a/18-securing-ai-agents/README.md
+++ b/18-securing-ai-agents/README.md
@@ -52,8 +52,7 @@ A receipt is a JSON object that records what an agent did, signed with a digital
 flowchart LR
     A[Agent invokes a tool] --> B[Build receipt payload]
     B --> C[Canonicalize JSON RFC 8785]
-    C --> D[SHA-256 hash]
-    D --> E[Ed25519 sign]
+    C --> E[Ed25519 sign canonical bytes]
     E --> F[Receipt with signature]
     F --> G[Auditor verifies offline]
     G --> H{Signature valid?}
@@ -136,10 +135,9 @@ payload = {
     "previous_receipt_hash": None,
 }
 
-# Canonicalize, hash, sign.
+# Canonicalize and sign the JCS bytes directly. PureEdDSA hashes internally.
 canonical_bytes = canonicalize(payload)
-message_hash = hashlib.sha256(canonical_bytes).digest()
-signature_bytes = signing_key.sign(message_hash).signature
+signature_bytes = signing_key.sign(canonical_bytes).signature
 
 # Attach a structured signature object.
 receipt = {
@@ -179,11 +177,10 @@ def verify_receipt(receipt: dict) -> bool:
     payload = {k: v for k, v in receipt.items() if k != "signature"}
 
     canonical_bytes = canonicalize(payload)
-    message_hash = hashlib.sha256(canonical_bytes).digest()
 
     try:
         verify_key = signing.VerifyKey(b64url_decode(sig_obj["public_key"]))
-        verify_key.verify(message_hash, b64url_decode(sig_obj["sig"]))
+        verify_key.verify(canonical_bytes, b64url_decode(sig_obj["sig"]))
         return True
     except BadSignatureError:
         return False
@@ -256,7 +253,7 @@ A common mistake is to assume that "we have receipts" means "we are governed." I
 
 Item 3 above is worth its own section: an action receipt says "this key signed this content," never "a human authorized this." For high-risk actions (refunds, deletions, wire transfers), governance frameworks increasingly require exactly that missing statement, and it is producible with the same primitives you already built in this lesson.
 
-The follow-on notebook `code_samples/human-authorization-receipts.ipynb` adds a second receipt kind, `human.approval.v1`, in the same envelope shape as the lesson's receipts (a typed payload signed by Ed25519 over its canonical SHA-256, with the `signature` object outside the signed bytes). A named approver signs the **full canonical action and its digest** before execution; the agent's action receipt carries the **same action digest** and a `parent_approval_ref`, the `receipt_hash` of the approval, the same convention as `previous_receipt_hash` in the chain you built above. One `verify_chain` walks both artifacts under **separate pinned key registries** (approver keys vs agent keys), so the code path is shared but the authorities never are.
+The follow-on notebook `code_samples/human-authorization-receipts.ipynb` adds a second receipt kind, `human.approval.v1`, in the same envelope shape as the lesson's receipts (a typed payload signed by Ed25519 over its canonical JCS bytes, with the `signature` object outside the signed bytes). A named approver signs the **full canonical action and its digest** before execution; the agent's action receipt carries the **same action digest** and a `parent_approval_ref`, the `receipt_hash` of the approval, the same convention as `previous_receipt_hash` in the chain you built above. One `verify_chain` walks both artifacts under **separate pinned key registries** (approver keys vs agent keys), so the code path is shared but the authorities never are.
 
 The property this buys, stated carefully: *the human approved this exact action, and the agent executed exactly that approved action.* The notebook's refusal fixtures are what make the property real rather than asserted:
 
@@ -264,7 +261,7 @@ The property this buys, stated carefully: *the human approved this exact action,
 - **stale authority**: a signature that still verifies, refused anyway because the policy version moved, the approver key was rotated out of the pinned registry, or the approval expired before execution;
 - **digest substitution**: a validly signed action receipt pointing at a *real* approval that binds a *different* canonical action.
 
-Each failure refuses with a distinct reason, so an auditor reading a refusal can tell whether authority went stale or the executed action changed. The rule the notebook teaches: a signed approval is not authority by itself. Authority exists only if both receipts still bind to the same canonical action at execution time. The co-signature path in the same Internet-Draft this lesson follows (`draft-farley-acta-signed-receipts`) is the standards-track shape of this pattern.
+Each failure refuses with a distinct reason, so an auditor reading a refusal can tell whether authority went stale or the executed action changed. The rule the notebook teaches: a signed approval is not authority by itself. Authority exists only if both receipts still bind to the same canonical action at execution time. The human-approval receipt is an educational composition defined by this lesson, not a receipt type defined by `draft-farley-acta-signed-receipts`.
 
 ## Production References
 
@@ -273,7 +270,7 @@ The Python code in this lesson is intentionally minimal so you can read every li
 1. **Build directly on the cryptographic primitives.** The 50 lines you saw above are sufficient for many use cases. PyNaCl (Ed25519) and the `jcs` package (canonical JSON) are well-maintained and audited libraries.
 
 2. **Use a production receipt library.** Several open-source projects implement the same pattern with additional features (key rotation, batch verification, JWK Set distribution, integration with policy engines):
-   - The receipt format used in this lesson follows an IETF Internet-Draft ([`draft-farley-acta-signed-receipts`](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/), revision 02) currently in the standards process, with a shared conformance suite ([agent-governance-testvectors](https://github.com/ScopeBlind/agent-governance-testvectors)) that independent implementations cross-verify against for byte-identical canonical output.
+   - The signing pipeline uses the JCS and signature-scope conventions in an independent IETF Internet-Draft ([`draft-farley-acta-signed-receipts`](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/), revision 02). This lesson's flat educational receipt differs from the draft's `{payload, signature}` envelope and is not presented as a conformant implementation. The draft publishes a shared conformance suite ([agent-governance-testvectors](https://github.com/ScopeBlind/agent-governance-testvectors)) for implementations targeting its wire format.
    - The Microsoft Agent Governance Toolkit composes receipts with Cedar-based policy decisions; see Tutorial 33 in that repository for an end-to-end example.
    - The `protect-mcp` (npm) and `@veritasacta/verify` (npm) packages provide a Node-based implementation of receipt signing and offline verification, intended for wrapping any MCP server with a tamper-evident audit trail, including a held-for-co-sign flow in which a paused action emits an approval receipt bound to the action digest (WebAuthn-backed in the desktop flow), the same approval-receipt pattern as the human-authorization notebook above.
    - The **[nobulex](https://github.com/arian-gogani/nobulex)** Python SDK (`pip install nobulex`) provides the same Ed25519 + JCS signing pattern in Python with LangChain and CrewAI integrations, including published cross-validation test vectors and a compliance mapping contributed via [OWASP PR #2210](https://github.com/OWASP/CheatSheetSeries/pull/2210).
@@ -297,7 +294,7 @@ Yes. Ed25519 verification requires only the public key and the signed bytes. No 
 <details>
 <summary>Answer</summary>
 
-Verification fails. The signature was computed over the canonical bytes of the original payload; modifying any field changes the canonical bytes, which changes the SHA-256 hash, which makes the signature invalid. The attacker would need the private key to produce a fresh valid signature, which they do not have.
+Verification fails. The signature was computed over the canonical bytes of the original payload; modifying any field changes those bytes, which makes the signature invalid. The attacker would need the private key to produce a fresh valid signature, which they do not have.
 </details>
 
 **3. Why does the receipt include a `tool_args_hash` and `result_hash` rather than the raw arguments and result?**
@@ -390,4 +387,3 @@ This lesson covers single-receipt signing and hash-chained sequences. The same p
 ## Previous Lesson
 
 [Creating Local AI Agents](../17-creating-local-ai-agents/README.md)
-

--- a/18-securing-ai-agents/code_samples/18-signed-receipts.ipynb
+++ b/18-securing-ai-agents/code_samples/18-signed-receipts.ipynb
@@ -33,19 +33,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "be69941d",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T04:55:20.865506Z",
+     "iopub.status.busy": "2026-08-18T04:55:20.865397Z",
+     "iopub.status.idle": "2026-08-18T04:55:21.725418Z",
+     "shell.execute_reply": "2026-08-18T04:55:21.724833Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33mWARNING: Cache entry deserialization failed, entry ignored\u001b[0m\u001b[33m\r\n",
+      "\u001b[0m\u001b[33mWARNING: Cache entry deserialization failed, entry ignored\u001b[0m\u001b[33m\r\n",
+      "\u001b[0m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
-    "!pip install -q pynacl jcs"
+    "%pip install -q pynacl jcs"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "76f7d45e",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T04:55:21.726862Z",
+     "iopub.status.busy": "2026-08-18T04:55:21.726749Z",
+     "iopub.status.idle": "2026-08-18T04:55:21.734882Z",
+     "shell.execute_reply": "2026-08-18T04:55:21.734438Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import json\n",
@@ -70,9 +101,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "df7e2c63",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T04:55:21.736368Z",
+     "iopub.status.busy": "2026-08-18T04:55:21.736272Z",
+     "iopub.status.idle": "2026-08-18T04:55:21.738829Z",
+     "shell.execute_reply": "2026-08-18T04:55:21.738382Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def b64url_nopad(data: bytes) -> str:\n",
@@ -110,10 +148,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "34f1cd12",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T04:55:21.740211Z",
+     "iopub.status.busy": "2026-08-18T04:55:21.740136Z",
+     "iopub.status.idle": "2026-08-18T04:55:21.742208Z",
+     "shell.execute_reply": "2026-08-18T04:55:21.741911Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Public key (Ed25519, 32 bytes): g3SyD_ecOKa1L8RQ79-pDy9em81H-O_jzp9VG4a3EP0\n"
+     ]
+    }
+   ],
    "source": [
     "signing_key = signing.SigningKey.generate()\n",
     "verify_key = signing_key.verify_key\n",
@@ -134,10 +187,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "dfa7feb1",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T04:55:21.743346Z",
+     "iopub.status.busy": "2026-08-18T04:55:21.743276Z",
+     "iopub.status.idle": "2026-08-18T04:55:21.746052Z",
+     "shell.execute_reply": "2026-08-18T04:55:21.745561Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"type\": \"agent.tool_call.v1\",\n",
+      "  \"agent_id\": \"contoso-travel-bot\",\n",
+      "  \"tool_name\": \"lookup_flights\",\n",
+      "  \"tool_args_hash\": \"sha256:47578acca4df262c8f172b91493b818a26d042e7beb8e7b121e2bc3776152746\",\n",
+      "  \"result_hash\": \"sha256:556447bf01c3c33285086d224b3d6fb4cd7b620b5151fbbebe67e7ff81cdde7a\",\n",
+      "  \"policy_id\": \"contoso-travel-policy-v3\",\n",
+      "  \"timestamp\": \"2026-08-18T04:55:21Z\",\n",
+      "  \"sequence\": 0,\n",
+      "  \"previous_receipt_hash\": null\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "tool_args = {\n",
     "    \"origin\": \"SYD\",\n",
@@ -177,18 +255,47 @@
     "Three steps:\n",
     "\n",
     "1. Canonicalize the payload using JCS so two implementations producing the same logical receipt produce byte-identical bytes.\n",
-    "2. Hash the canonical bytes with SHA-256.\n",
-    "3. Sign the hash with the Ed25519 private key.\n",
+    "2. Sign the canonical bytes directly with the Ed25519 private key. PureEdDSA hashes the message internally, so an extra pre-hash would change the protocol.\n",
     "\n",
     "The signature is then attached to the original payload to produce the final receipt."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "f39e3230",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T04:55:21.747145Z",
+     "iopub.status.busy": "2026-08-18T04:55:21.747072Z",
+     "iopub.status.idle": "2026-08-18T04:55:21.749497Z",
+     "shell.execute_reply": "2026-08-18T04:55:21.749083Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"type\": \"agent.tool_call.v1\",\n",
+      "  \"agent_id\": \"contoso-travel-bot\",\n",
+      "  \"tool_name\": \"lookup_flights\",\n",
+      "  \"tool_args_hash\": \"sha256:47578acca4df262c8f172b91493b818a26d042e7beb8e7b121e2bc3776152746\",\n",
+      "  \"result_hash\": \"sha256:556447bf01c3c33285086d224b3d6fb4cd7b620b5151fbbebe67e7ff81cdde7a\",\n",
+      "  \"policy_id\": \"contoso-travel-policy-v3\",\n",
+      "  \"timestamp\": \"2026-08-18T04:55:21Z\",\n",
+      "  \"sequence\": 0,\n",
+      "  \"previous_receipt_hash\": null,\n",
+      "  \"signature\": {\n",
+      "    \"alg\": \"EdDSA\",\n",
+      "    \"sig\": \"Eu3MmrOSdGq2DuemkjNSPKfz5xbr18okNeTU11NJu2usnsnKtC-pjq2PZM1Oap-WXdVgYkL4iW6SeWPSZ2M9BQ\",\n",
+      "    \"public_key\": \"g3SyD_ecOKa1L8RQ79-pDy9em81H-O_jzp9VG4a3EP0\"\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "def sign_receipt(payload: dict, signing_key: signing.SigningKey, verify_key) -> dict:\n",
     "    \"\"\"\n",
@@ -196,8 +303,7 @@
     "    The 'signature' and 'public_key' fields are NOT part of the canonical signed bytes.\n",
     "    \"\"\"\n",
     "    canonical = canonicalize(payload)\n",
-    "    message_hash = hashlib.sha256(canonical).digest()\n",
-    "    signature_bytes = signing_key.sign(message_hash).signature\n",
+    "    signature_bytes = signing_key.sign(canonical).signature\n",
     "    return {\n",
     "        **payload,\n",
     "        \"signature\": {\n",
@@ -218,17 +324,33 @@
    "source": [
     "### Step 1.4: Verify the receipt\n",
     "\n",
-    "Verification reverses the process. We strip the signature, recompute the canonical hash, and check the signature against the public key in the receipt.\n",
+    "Verification reverses the process. We strip the signature, recompute the canonical bytes, and check the signature against the public key in the receipt.\n",
     "\n",
     "An auditor doing this verification needs nothing from us except the receipt itself. No service to call, no key directory to query, no trust required."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "15c94d27",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T04:55:21.750540Z",
+     "iopub.status.busy": "2026-08-18T04:55:21.750483Z",
+     "iopub.status.idle": "2026-08-18T04:55:21.754397Z",
+     "shell.execute_reply": "2026-08-18T04:55:21.753981Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Receipt is valid: True\n",
+      "Pre-hashed receipt valid: False\n"
+     ]
+    }
+   ],
    "source": [
     "def verify_receipt(receipt: dict) -> bool:\n",
     "    \"\"\"\n",
@@ -243,11 +365,9 @@
     "    payload = {k: v for k, v in receipt.items() if k != \"signature\"}\n",
     "\n",
     "    canonical = canonicalize(payload)\n",
-    "    message_hash = hashlib.sha256(canonical).digest()\n",
-    "\n",
     "    try:\n",
     "        verify_key = signing.VerifyKey(b64url_decode(sig_obj[\"public_key\"]))\n",
-    "        verify_key.verify(message_hash, b64url_decode(sig_obj[\"sig\"]))\n",
+    "        verify_key.verify(canonical, b64url_decode(sig_obj[\"sig\"]))\n",
     "        return True\n",
     "    except BadSignatureError:\n",
     "        return False\n",
@@ -256,7 +376,17 @@
     "        return False\n",
     "\n",
     "is_valid = verify_receipt(receipt)\n",
-    "print(f\"Receipt is valid: {is_valid}\")"
+    "print(f\"Receipt is valid: {is_valid}\")\n",
+    "\n",
+    "# Regression control for the signature scope in draft revision 02. A receipt\n",
+    "# signed over SHA-256(JCS(payload)) is a signature over different bytes and\n",
+    "# must not verify as a direct-JCS Ed25519 receipt.\n",
+    "prehashed_signature = signing_key.sign(hashlib.sha256(canonicalize(payload)).digest()).signature\n",
+    "prehashed_receipt = {\n",
+    "    **receipt,\n",
+    "    \"signature\": {**receipt[\"signature\"], \"sig\": b64url_nopad(prehashed_signature)},\n",
+    "}\n",
+    "print(f\"Pre-hashed receipt valid: {verify_receipt(prehashed_receipt)}\")"
    ]
   },
   {
@@ -264,7 +394,7 @@
    "id": "d25454d4",
    "metadata": {},
    "source": [
-    "You should see `Receipt is valid: True`. The agent has produced its first cryptographically signed audit record."
+    "You should see `Receipt is valid: True` and `Pre-hashed receipt valid: False`. The positive case proves the direct-JCS signing path works; the negative control makes the signature-scope rule executable instead of leaving it as prose."
    ]
   },
   {
@@ -281,10 +411,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "3038feec",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T04:55:21.755540Z",
+     "iopub.status.busy": "2026-08-18T04:55:21.755463Z",
+     "iopub.status.idle": "2026-08-18T04:55:21.757938Z",
+     "shell.execute_reply": "2026-08-18T04:55:21.757542Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original policy_id:  contoso-travel-policy-v3\n",
+      "Tampered policy_id:  contoso-travel-policy-PERMISSIVE\n",
+      "\n",
+      "Tampered receipt valid? False\n"
+     ]
+    }
+   ],
    "source": [
     "import copy\n",
     "\n",
@@ -308,7 +456,7 @@
    "source": [
     "### What just happened?\n",
     "\n",
-    "When we changed `policy_id`, the canonical bytes changed. The SHA-256 hash of those bytes changed. The signature (which was over the original hash) no longer matches the new hash. Verification correctly returns `False`.\n",
+    "When we changed `policy_id`, the canonical bytes changed. The signature (which was over the original canonical bytes) no longer matches. Verification correctly returns `False`.\n",
     "\n",
     "There is no way to modify any field of the receipt and still have it verify, unless the attacker has the private key. As long as the private key is in a key vault and the public key is published, tampering is impossible to hide.\n",
     "\n",
@@ -335,9 +483,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "c7c6473b",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T04:55:21.759016Z",
+     "iopub.status.busy": "2026-08-18T04:55:21.758951Z",
+     "iopub.status.idle": "2026-08-18T04:55:21.761199Z",
+     "shell.execute_reply": "2026-08-18T04:55:21.760773Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def receipt_hash(receipt: dict) -> str:\n",
@@ -377,10 +532,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "1b8b1231",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T04:55:21.762260Z",
+     "iopub.status.busy": "2026-08-18T04:55:21.762180Z",
+     "iopub.status.idle": "2026-08-18T04:55:21.765283Z",
+     "shell.execute_reply": "2026-08-18T04:55:21.764846Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Receipt 0: tool=lookup_flights, prev=None\n",
+      "Receipt 1: tool=hold_seat, prev=sha256:d54d1e138bb080dd6bd825d9f015efc74ad6c7f78ee9504d0b68b39d0733b39c\n",
+      "Receipt 2: tool=confirm_booking, prev=sha256:9fbe5dc2ffcffd7d167ef13a744aecd578e474fb536cb7104ddb1a359607f2f6\n"
+     ]
+    }
+   ],
    "source": [
     "# Build a chain of three receipts: search, hold, book.\n",
     "r0 = make_receipt(\n",
@@ -420,10 +592,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "5dd91fcc",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T04:55:21.766335Z",
+     "iopub.status.busy": "2026-08-18T04:55:21.766275Z",
+     "iopub.status.idle": "2026-08-18T04:55:21.770042Z",
+     "shell.execute_reply": "2026-08-18T04:55:21.769660Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Receipt 0 (    lookup_flights): VALID\n",
+      "Receipt 1 (         hold_seat): VALID\n",
+      "Receipt 2 (   confirm_booking): VALID\n"
+     ]
+    }
+   ],
    "source": [
     "def verify_chain(chain: list) -> list[dict]:\n",
     "    \"\"\"\n",
@@ -470,10 +659,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "12d3201f",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T04:55:21.771076Z",
+     "iopub.status.busy": "2026-08-18T04:55:21.771016Z",
+     "iopub.status.idle": "2026-08-18T04:55:21.774857Z",
+     "shell.execute_reply": "2026-08-18T04:55:21.774559Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Receipt 0 (    lookup_flights): VALID\n",
+      "Receipt 1 (         hold_seat): INVALID (failed: signature)\n",
+      "Receipt 2 (   confirm_booking): INVALID (failed: chain link)\n"
+     ]
+    }
+   ],
    "source": [
     "# Tamper with the middle receipt: change the hold duration to something\n",
     "# more permissive than was actually authorized.\n",
@@ -523,9 +729,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "7ee11c4a",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T04:55:21.775995Z",
+     "iopub.status.busy": "2026-08-18T04:55:21.775934Z",
+     "iopub.status.idle": "2026-08-18T04:55:21.778247Z",
+     "shell.execute_reply": "2026-08-18T04:55:21.777904Z"
+    }
+   },
    "outputs": [],
    "source": [
     "class ReceiptedTool:\n",
@@ -567,10 +780,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "6fe5e0d8",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T04:55:21.779217Z",
+     "iopub.status.busy": "2026-08-18T04:55:21.779156Z",
+     "iopub.status.idle": "2026-08-18T04:55:21.783643Z",
+     "shell.execute_reply": "2026-08-18T04:55:21.783317Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tool was called 3 times.\n",
+      "Each call produced a signed receipt linked to the previous one.\n",
+      "\n",
+      "Receipt 0 (lookup_flights): VALID\n",
+      "Receipt 1 (lookup_flights): VALID\n",
+      "Receipt 2 (lookup_flights): VALID\n"
+     ]
+    }
+   ],
    "source": [
     "# Example tool: a mock flight lookup. In a real Microsoft Agent Framework deployment,\n",
     "# this would be a function passed to FoundryChatClient as a tool.\n",
@@ -669,8 +902,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.10"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.5"
   }
  },
  "nbformat": 4,

--- a/18-securing-ai-agents/code_samples/human-authorization-receipts.ipynb
+++ b/18-securing-ai-agents/code_samples/human-authorization-receipts.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "The lesson proves what the **agent** did and what the **gate** decided. This notebook adds the missing half: proof that a **named human** approved the **exact** action — a separate, human-held signature over the full canonical action, verified offline.\n",
     "\n",
-    "Both artifacts here use the **same envelope shape as the lesson's receipts**: a flat payload with a `type` field, signed by Ed25519 over the SHA-256 of the canonical payload bytes, with a structured `signature` object attached (and excluded from the signed bytes). The approval receipt is a new `type` (`human.approval.v1`) alongside the action type, so one `verify_chain` covers both artifact kinds with the same code path you built in the main notebook. This is also the shape of the co-signature path in the Internet-Draft the lesson follows (draft-farley-acta-signed-receipts).\n",
+    "Both artifacts here use the **same envelope shape as the lesson's receipts**: a flat payload with a `type` field, signed by Ed25519 over the canonical JCS bytes directly, with a structured `signature` object attached (and excluded from the signed bytes). The approval receipt is a new `type` (`human.approval.v1`) alongside the action type, so one `verify_chain` covers both artifact kinds with the same code path you built in the main notebook. This human-approval receipt is an educational composition defined here, not a receipt type defined by draft-farley-acta-signed-receipts.\n",
     "\n",
     "One deliberate upgrade over the demo verifier in the main notebook: the verifier here resolves `signature.key_id` against a **pinned key registry** instead of trusting a public key carried inside the receipt. That is the production posture the lesson's own checklist recommends (\"publish the verification public key\"), and it is what makes forgery a refusal instead of a bring-your-own-key bypass.\n",
     "\n",
@@ -22,10 +22,10 @@
    "id": "e1d43988",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T14:48:44.280478Z",
-     "iopub.status.busy": "2026-07-08T14:48:44.280421Z",
-     "iopub.status.idle": "2026-07-08T14:48:44.288154Z",
-     "shell.execute_reply": "2026-07-08T14:48:44.287750Z"
+     "iopub.execute_input": "2026-08-18T04:54:55.127670Z",
+     "iopub.status.busy": "2026-08-18T04:54:55.127575Z",
+     "iopub.status.idle": "2026-08-18T04:54:55.140993Z",
+     "shell.execute_reply": "2026-08-18T04:54:55.140388Z"
     }
    },
    "outputs": [],
@@ -68,10 +68,10 @@
    "id": "cf2fd4f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T14:48:44.289325Z",
-     "iopub.status.busy": "2026-07-08T14:48:44.289258Z",
-     "iopub.status.idle": "2026-07-08T14:48:44.291320Z",
-     "shell.execute_reply": "2026-07-08T14:48:44.291052Z"
+     "iopub.execute_input": "2026-08-18T04:54:55.142499Z",
+     "iopub.status.busy": "2026-08-18T04:54:55.142380Z",
+     "iopub.status.idle": "2026-08-18T04:54:55.145054Z",
+     "shell.execute_reply": "2026-08-18T04:54:55.144430Z"
     }
    },
    "outputs": [
@@ -113,10 +113,10 @@
    "id": "167d10ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T14:48:44.292321Z",
-     "iopub.status.busy": "2026-07-08T14:48:44.292271Z",
-     "iopub.status.idle": "2026-07-08T14:48:44.295888Z",
-     "shell.execute_reply": "2026-07-08T14:48:44.295467Z"
+     "iopub.execute_input": "2026-08-18T04:54:55.146412Z",
+     "iopub.status.busy": "2026-08-18T04:54:55.146332Z",
+     "iopub.status.idle": "2026-08-18T04:54:55.150974Z",
+     "shell.execute_reply": "2026-08-18T04:54:55.150593Z"
     }
    },
    "outputs": [],
@@ -134,12 +134,12 @@
     "CURRENT_POLICY = {\"policy_version\": \"refunds-v3\"}\n",
     "\n",
     "def sign_receipt(payload: dict, sk: SigningKey, key_id: str) -> dict:\n",
-    "    \"\"\"Same signing pipeline as the lesson: Ed25519 over the SHA-256 of the\n",
-    "    canonical payload; the signature object is NOT part of the signed bytes.\"\"\"\n",
-    "    message_hash = hashlib.sha256(canonicalize(payload)).digest()\n",
+    "    \"\"\"Same signing pipeline as the lesson: Ed25519 over the canonical JCS\n",
+    "    bytes directly; the signature object is NOT part of the signed bytes.\"\"\"\n",
+    "    canonical = canonicalize(payload)\n",
     "    return {\n",
     "        **payload,\n",
-    "        \"signature\": {\"alg\": \"EdDSA\", \"sig\": b64url_nopad(sk.sign(message_hash).signature), \"key_id\": key_id},\n",
+    "        \"signature\": {\"alg\": \"EdDSA\", \"sig\": b64url_nopad(sk.sign(canonical).signature), \"key_id\": key_id},\n",
     "    }\n",
     "\n",
     "def verify_envelope(receipt, expected_type: str, trusted_keys: dict):\n",
@@ -159,11 +159,11 @@
     "    if pub is None:\n",
     "        return (False, f\"stale authority: key_id {sig_obj.get('key_id')!r} is not in the pinned registry (unknown or rotated out)\")\n",
     "    # Reconstruct the signed bytes exactly as the lesson does: everything except\n",
-    "    # the signature object, canonicalized, hashed.\n",
+    "    # the signature object, canonicalized and passed directly to Ed25519.\n",
     "    payload = {k: v for k, v in receipt.items() if k != \"signature\"}\n",
     "    try:\n",
-    "        message_hash = hashlib.sha256(canonicalize(payload)).digest()\n",
-    "        VerifyKey(b64url_decode(pub)).verify(message_hash, b64url_decode(sig_obj.get(\"sig\") or \"\"))\n",
+    "        canonical = canonicalize(payload)\n",
+    "        VerifyKey(b64url_decode(pub)).verify(canonical, b64url_decode(sig_obj.get(\"sig\") or \"\"))\n",
     "    except (CryptoError, TypeError, ValueError, base64.binascii.Error):\n",
     "        return (False, \"signature invalid (forged, tampered, or malformed)\")\n",
     "    return (True, \"envelope ok\")\n",
@@ -192,10 +192,10 @@
    "id": "8f816895",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T14:48:44.296887Z",
-     "iopub.status.busy": "2026-07-08T14:48:44.296827Z",
-     "iopub.status.idle": "2026-07-08T14:48:44.299165Z",
-     "shell.execute_reply": "2026-07-08T14:48:44.298822Z"
+     "iopub.execute_input": "2026-08-18T04:54:55.152098Z",
+     "iopub.status.busy": "2026-08-18T04:54:55.152026Z",
+     "iopub.status.idle": "2026-08-18T04:54:55.155036Z",
+     "shell.execute_reply": "2026-08-18T04:54:55.154492Z"
     }
    },
    "outputs": [
@@ -233,10 +233,10 @@
    "id": "f6639b4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T14:48:44.300036Z",
-     "iopub.status.busy": "2026-07-08T14:48:44.299982Z",
-     "iopub.status.idle": "2026-07-08T14:48:44.304448Z",
-     "shell.execute_reply": "2026-07-08T14:48:44.304128Z"
+     "iopub.execute_input": "2026-08-18T04:54:55.156505Z",
+     "iopub.status.busy": "2026-08-18T04:54:55.156431Z",
+     "iopub.status.idle": "2026-08-18T04:54:55.161815Z",
+     "shell.execute_reply": "2026-08-18T04:54:55.161387Z"
     }
    },
    "outputs": [
@@ -333,10 +333,10 @@
    "id": "79c08d86",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T14:48:44.305540Z",
-     "iopub.status.busy": "2026-07-08T14:48:44.305483Z",
-     "iopub.status.idle": "2026-07-08T14:48:44.320088Z",
-     "shell.execute_reply": "2026-07-08T14:48:44.319845Z"
+     "iopub.execute_input": "2026-08-18T04:54:55.163209Z",
+     "iopub.status.busy": "2026-08-18T04:54:55.163123Z",
+     "iopub.status.idle": "2026-08-18T04:54:55.181036Z",
+     "shell.execute_reply": "2026-08-18T04:54:55.180617Z"
     }
    },
    "outputs": [

--- a/18-securing-ai-agents/code_samples/sample_receipts/01_valid_receipt.json
+++ b/18-securing-ai-agents/code_samples/sample_receipts/01_valid_receipt.json
@@ -10,7 +10,7 @@
   "previous_receipt_hash": null,
   "signature": {
     "alg": "EdDSA",
-    "sig": "ZrU64gQd-rs_jgYaHFl2PbuhY6PY8ZsapXBf7GZSxym0Egbvn9dJmFOuO_fj7T4AcV80lzxylaXpznlKUmJSDw",
+    "sig": "4YrLwSSB8tLWeqKDbL7Wya9fgdLrSFvPHmJZ7y7E5IROkVw7RJ0ZnHitEKyLiRdd5WDDqJ2wMjeivrmJZKLoBw",
     "public_key": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
   }
 }

--- a/18-securing-ai-agents/code_samples/sample_receipts/02_tampered_receipt.json
+++ b/18-securing-ai-agents/code_samples/sample_receipts/02_tampered_receipt.json
@@ -10,7 +10,7 @@
   "previous_receipt_hash": null,
   "signature": {
     "alg": "EdDSA",
-    "sig": "ZrU64gQd-rs_jgYaHFl2PbuhY6PY8ZsapXBf7GZSxym0Egbvn9dJmFOuO_fj7T4AcV80lzxylaXpznlKUmJSDw",
+    "sig": "4YrLwSSB8tLWeqKDbL7Wya9fgdLrSFvPHmJZ7y7E5IROkVw7RJ0ZnHitEKyLiRdd5WDDqJ2wMjeivrmJZKLoBw",
     "public_key": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
   }
 }

--- a/18-securing-ai-agents/code_samples/sample_receipts/03_chain_three_receipts.json
+++ b/18-securing-ai-agents/code_samples/sample_receipts/03_chain_three_receipts.json
@@ -11,7 +11,7 @@
     "previous_receipt_hash": null,
     "signature": {
       "alg": "EdDSA",
-      "sig": "5rQAm4RMiAlfXmqufD9HJWQnFxRBbkpKkQmktgUGQUzZcEqsVofLsXmr7RkizTqYOCSaWjCGd-_Yy-7jloo1Cg",
+      "sig": "i6k11Rl6VvDSwjowvu15CDlK0rDZT6dU0JGc8dq52_HUA7lJ-7GWzPfb2nfLFP9zTEAEsHh01MH8idVjQ6q-Bw",
       "public_key": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
     }
   },
@@ -24,10 +24,10 @@
     "policy_id": "contoso-travel-policy-v3",
     "timestamp": "2026-04-25T14:30:00Z",
     "sequence": 1,
-    "previous_receipt_hash": "sha256:99afc07cbdc4341c52d958dfeebea77c86cbb901c620c3ca762db0a9fc2086b5",
+    "previous_receipt_hash": "sha256:66d8867fa8fa501e91e0ceaa1b75d0747c0f48b71cfb95d7255963098887d6fb",
     "signature": {
       "alg": "EdDSA",
-      "sig": "cLcIEcm9aLdV4FelzCMNfBv-CAhqXsSOFoJHXyeWyzMT-V5L0zj8vPm28cf-zjEzNvtoMbOOeGES35wduMT-Bw",
+      "sig": "wRcwv6pCTwxDn_GtLFyO4skriw6pP_rS1siiCy8Ij9PXB496G4UmCxIzmY1hN12VtezuwkRKm33N73GBFgWOCg",
       "public_key": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
     }
   },
@@ -40,10 +40,10 @@
     "policy_id": "contoso-travel-policy-v3",
     "timestamp": "2026-04-25T14:30:00Z",
     "sequence": 2,
-    "previous_receipt_hash": "sha256:79cbd0a4a623b2d9a7d7a35aafae725a35449a9e07fb4fdf6f6beb5abc8cca83",
+    "previous_receipt_hash": "sha256:3e4bbfab545ae67a2839fe3113bce1a3038b4eb77f9eaec59bc3926d048473d1",
     "signature": {
       "alg": "EdDSA",
-      "sig": "aXwWF0mOAGGUfLM_hY6Ut46Z3PWZ0o6w-yzqYToSI262YMnIX979SzeNKz48YeuPxVFKFbuB0m9A4GiS0aQzDQ",
+      "sig": "l3-EGdBRCPlZAs05aNesMef8PjWVLAfRhoZYNHwKeoStLBIxyLiJw8N0oW8bkBrzDlBlTe5seqrEld1XU7LECA",
       "public_key": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
     }
   }

--- a/18-securing-ai-agents/code_samples/sample_receipts/README.md
+++ b/18-securing-ai-agents/code_samples/sample_receipts/README.md
@@ -8,6 +8,10 @@ Three pre-generated receipt files for inspection without running the notebook.
 | `02_tampered_receipt.json` | The same receipt with one field modified after signing. Verification returns False. |
 | `03_chain_three_receipts.json` | A chain of three valid receipts (search, hold, book) with `previous_receipt_hash` linking each to the prior one. |
 
+The fixtures sign the payload's canonical JCS bytes directly with Ed25519.
+SHA-256 remains in use for content digests and receipt-chain links, not as an
+extra pre-hash before signing.
+
 ## Verifying the samples
 
 The notebook walks through verification in four sections. To verify these fixtures

--- a/18-securing-ai-agents/code_samples/sample_receipts/generate_fixtures.py
+++ b/18-securing-ai-agents/code_samples/sample_receipts/generate_fixtures.py
@@ -35,8 +35,7 @@ def sha256_canonical(obj) -> str:
 
 def sign_receipt(payload: dict, signing_key, verify_key) -> dict:
     canonical = canonicalize(payload)
-    message_hash = hashlib.sha256(canonical).digest()
-    sig_bytes = signing_key.sign(message_hash).signature
+    sig_bytes = signing_key.sign(canonical).signature
     return {
         **payload,
         "signature": {


### PR DESCRIPTION
## What changed

- sign and verify the JCS-canonical payload bytes directly in both Lesson 18 notebooks
- add an executable negative control showing that the former `SHA-256(JCS(payload))` pre-hash form does not verify under the revised signature scope
- regenerate the deterministic sample receipts and chain links with the corrected signing input
- update the lesson prose and diagram to match the running code
- state the standards boundary precisely: the lesson reuses the draft's JCS and signature-scope conventions, while its flat educational receipt is not the draft's `{payload, signature}` wire format
- identify `human.approval.v1` as this lesson's educational composition rather than a receipt type defined by the draft

## Why

`draft-farley-acta-signed-receipts-02` changed Section 5.6 to require PureEdDSA over the canonical JCS bytes directly and to forbid an intermediate SHA-256 pre-hash. The lesson and its human-authorization follow-on still implemented the earlier pre-hashed convention, even though the README referenced revision 02.

This made the examples internally self-consistent but incompatible with revision 02's normative signature scope. It also overstated the relationship between the educational envelope and the independent Internet-Draft.

SHA-256 remains in use where intended: content digests, action digests, and receipt-chain links.

## Validation

- executed `18-signed-receipts.ipynb` top to bottom with `nbconvert`
  - valid direct-JCS receipt: `True`
  - pre-hashed regression control: `False`
  - tampered receipt: `False`
  - three-receipt chain: `3/3` valid
  - tampered chain: modified receipt and successor link both invalid
- executed `human-authorization-receipts.ipynb` top to bottom with `nbconvert`
  - valid authorization chain executed
  - replay, forgery, malformed input, stale policy, stale key, expiry, and digest substitution all refused with their existing distinct reasons
- regenerated fixtures twice and confirmed byte-identical output on the second run
- independently verified the valid fixture, tampered fixture, all three chain signatures, and both chain links
- `python -m py_compile` on the fixture generator
- `git diff --check`
