### PR TITLE
[Fix] Scope MCP event replay to the original stream

### DIFF
--- a/11-agentic-protocols/code_samples/mcp-agents/README.md
+++ b/11-agentic-protocols/code_samples/mcp-agents/README.md
@@ -367,9 +367,24 @@ class SimpleEventStore(EventStore):
 
     async def replay_events_after(self, last_event_id: EventId, send_callback: EventCallback) -> StreamId | None:
         """Replay events after the specified ID for resumption."""
-        # Find events after the last known event and replay them
-        for _, event_id, message in self._events[start_index:]:
+        start_index = None
+        stream_id = None
+        for index, (event_stream_id, event_id, _) in enumerate(self._events):
+            if event_id == last_event_id:
+                start_index = index + 1
+                stream_id = event_stream_id
+                break
+
+        if start_index is None:
+            return None
+
+        # Replay only later events from the session's original stream.
+        for event_stream_id, event_id, message in self._events[start_index:]:
+            if event_stream_id != stream_id:
+                continue
             await send_callback(EventMessage(message, event_id))
+
+        return stream_id
 
 # From server/server.py - Passing event store to session manager
 def create_server_app(event_store: Optional[EventStore] = None) -> Starlette:

--- a/11-agentic-protocols/code_samples/mcp-agents/server/event_store.py
+++ b/11-agentic-protocols/code_samples/mcp-agents/server/event_store.py
@@ -48,28 +48,28 @@ class SimpleEventStore(EventStore):
     ) -> StreamId | None:
         """Replay events after the specified ID."""
         logger.info(f"Replaying events after {last_event_id}")
-        
-        # Find the index of the last event ID
+
+        # Find the last event and its stream. Event IDs are global, but replay
+        # must remain scoped to the stream being resumed.
         start_index = None
-        for i, (_, event_id, _) in enumerate(self._events):
+        stream_id = None
+        for i, (event_stream_id, event_id, _) in enumerate(self._events):
             if event_id == last_event_id:
                 start_index = i + 1
+                stream_id = event_stream_id
                 break
 
         if start_index is None:
-            # If event ID not found, start from beginning
-            start_index = 0
-            logger.info("Event ID not found, starting from beginning")
+            logger.warning(f"Event ID {last_event_id} not found")
+            return None
 
-        stream_id = None
         # Replay events
         replayed_count = 0
-        for _, event_id, message in self._events[start_index:]:
+        for event_stream_id, event_id, message in self._events[start_index:]:
+            if event_stream_id != stream_id:
+                continue
             await send_callback(EventMessage(message, event_id))
             replayed_count += 1
-            # Capture the stream ID from the first replayed event
-            if stream_id is None and len(self._events) > start_index:
-                stream_id = self._events[start_index][0]
 
         logger.info(f"Replayed {replayed_count} events, stream_id: {stream_id}")
         return stream_id

--- a/11-agentic-protocols/code_samples/mcp-agents/server/test_event_store.py
+++ b/11-agentic-protocols/code_samples/mcp-agents/server/test_event_store.py
@@ -1,0 +1,58 @@
+import unittest
+from unittest.mock import AsyncMock
+
+from event_store import SimpleEventStore
+from mcp.server.streamable_http import EventMessage
+from mcp.types import JSONRPCMessage, JSONRPCNotification
+
+
+def message(method: str) -> JSONRPCMessage:
+    return JSONRPCMessage(root=JSONRPCNotification(jsonrpc="2.0", method=method))
+
+
+class SimpleEventStoreTests(unittest.IsolatedAsyncioTestCase):
+    async def test_replay_is_limited_to_original_stream(self) -> None:
+        store = SimpleEventStore()
+        first = message("notifications/first")
+        other_stream = message("notifications/other")
+        expected = message("notifications/expected")
+
+        last_event_id = await store.store_event("stream-a", first)
+        await store.store_event("stream-b", other_stream)
+        expected_event_id = await store.store_event("stream-a", expected)
+
+        callback = AsyncMock()
+        stream_id = await store.replay_events_after(last_event_id, callback)
+
+        self.assertEqual(stream_id, "stream-a")
+        callback.assert_awaited_once()
+        replayed = callback.await_args.args[0]
+        self.assertIsInstance(replayed, EventMessage)
+        self.assertEqual(replayed.event_id, expected_event_id)
+        self.assertIs(replayed.message, expected)
+
+    async def test_unknown_event_id_does_not_replay(self) -> None:
+        store = SimpleEventStore()
+        await store.store_event("stream-a", message("notifications/first"))
+        callback = AsyncMock()
+
+        stream_id = await store.replay_events_after("missing", callback)
+
+        self.assertIsNone(stream_id)
+        callback.assert_not_awaited()
+
+    async def test_returns_stream_when_no_later_events_exist(self) -> None:
+        store = SimpleEventStore()
+        last_event_id = await store.store_event(
+            "stream-a", message("notifications/first")
+        )
+
+        callback = AsyncMock()
+        stream_id = await store.replay_events_after(last_event_id, callback)
+
+        self.assertEqual(stream_id, "stream-a")
+        callback.assert_not_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- scope `SimpleEventStore` replay to the stream that owns the supplied event ID
- return `None` for unknown event IDs instead of replaying the full event history
- add offline regression tests for interleaved streams and replay boundaries
- update the lesson snippet so it is complete and matches the implementation

## Problem

Event IDs are global within `SimpleEventStore`, but the previous replay loop emitted every event after the requested ID. With interleaved MCP sessions, resuming one stream could therefore replay messages belonging to another stream. The persistent SQLite example in the same module already filters by the original stream.

## Verification

```text
uv run --with "mcp<2" --with pydantic python -m unittest -v test_event_store.py
Ran 3 tests in 0.058s - OK

uv run --with ruff ruff check 11-agentic-protocols/code_samples/mcp-agents/server/test_event_store.py
All checks passed

git diff --check
clean
```

AI assistance disclosure: Codex assisted with repository analysis, implementation, and test drafting. I reviewed the change and verification results.