### PR TITLE
[Lesson-11] Add remote web search MCP exercise

### DIFF
--- a/11-agentic-protocols/README.md
+++ b/11-agentic-protocols/README.md
@@ -76,7 +76,7 @@ Imagine a user wants to book a flight using an AI assistant powered by MCP.
 
 ### Try a real remote MCP connection
 
-The optional [Parallel Search MCP exercise](./code_samples/parallel-search-mcp/README.md) uses the course's Python MCP SDK dependency to connect to a remote server, discover tool schemas, search the public web, and fetch page text. It requires no local server, Azure subscription, or Parallel API key. Running it sends the sample queries, URLs, and objectives to Parallel; anonymous access is rate limited.
+The optional [Parallel Search MCP exercise](./code_samples/parallel-search-mcp/README.md) uses the Python MCP SDK 1.x (`mcp[cli]>=1.28,<2`), installed in a separate virtual environment as shown in the exercise, to connect to a remote server, discover tool schemas, search the public web, and fetch page text. It requires no local server, Azure subscription, or Parallel API key. Running it sends the sample queries, URLs, and objectives to Parallel; anonymous access is rate limited.
 
 ## Agent-to-Agent Protocol (A2A)
 

--- a/11-agentic-protocols/README.md
+++ b/11-agentic-protocols/README.md
@@ -74,6 +74,10 @@ Imagine a user wants to book a flight using an AI assistant powered by MCP.
 
 5. **Further Interaction**: The AI assistant presents the flight options. Once you select a flight, the assistant might invoke the "book flight" tool on the same MCP server, completing the booking.
 
+### Try a real remote MCP connection
+
+The optional [Parallel Search MCP exercise](./code_samples/parallel-search-mcp/README.md) uses the course's Python MCP SDK dependency to connect to a remote server, discover tool schemas, search the public web, and fetch page text. It requires no local server, Azure subscription, or Parallel API key. Running it sends the sample queries, URLs, and objectives to Parallel; anonymous access is rate limited.
+
 ## Agent-to-Agent Protocol (A2A)
 
 While MCP focuses on connecting LLMs to tools, the **Agent-to-Agent (A2A) protocol** takes it a step further by enabling communication and collaboration between different AI agents.  A2A connects AI agents across different organizations, environments and tech stacks to complete a shared task.

--- a/11-agentic-protocols/code_samples/parallel-search-mcp/README.md
+++ b/11-agentic-protocols/code_samples/parallel-search-mcp/README.md
@@ -32,7 +32,7 @@ Running the script sends its search query, requested URL, objectives, and a rand
 3. **Search:** `web_search` receives both an objective and search queries, then returns public web results with source URLs and excerpts.
 4. **Fetch:** `web_fetch` extracts text from a known public documentation page. It does not control a browser or use your signed-in sessions.
 
-The output contains live results, so URLs and excerpts can change. The script prints the text representation of each tool response once, including warnings and any per-URL fetch errors. A fetch can contain successful pages and errors together; inspect both before using the results. An MCP tool error stops the script, and the whole exercise has a 90-second timeout. Connection failures and rate limits also surface as errors; wait before retrying rather than running repeated requests.
+The output contains live results, so URLs and excerpts can change. The script prints each complete tool response as JSON, including all content blocks, structured content, warnings, and any per-URL fetch errors. A fetch can contain successful pages and errors together; inspect both before using the results. An MCP tool error stops the script, and the whole exercise has a 90-second timeout. Connection failures and rate limits also surface as errors; wait before retrying rather than running repeated requests.
 
 Both calls share one randomly generated `session_id` for this exercise. This is separate from the HTTP transport session managed by the SDK.
 

--- a/11-agentic-protocols/code_samples/parallel-search-mcp/README.md
+++ b/11-agentic-protocols/code_samples/parallel-search-mcp/README.md
@@ -1,0 +1,41 @@
+# Try a remote MCP server with public web search
+
+This optional Lesson 11 exercise connects to [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) over Streamable HTTP. You can observe a real MCP connection, tool discovery, and tool calls without running a server locally. The script calls tools directly so you can inspect the protocol steps before connecting them to an agent.
+
+## Run the example
+
+Use Python 3.12 or later with the course's `mcp[cli]` dependency installed. If you have not installed the course dependencies, you can run this exercise in a virtual environment with just the MCP SDK:
+
+```bash
+python -m venv .venv
+# macOS / Linux:
+source .venv/bin/activate
+# Windows PowerShell instead:
+# .venv\Scripts\Activate.ps1
+python -m pip install "mcp[cli]"
+```
+
+From the repository root, run:
+
+```bash
+python 11-agentic-protocols/code_samples/parallel-search-mcp/client.py
+```
+
+No Azure subscription, model deployment, Parallel account, or Parallel API key is required for this exercise. The anonymous endpoint is `https://search.parallel.ai/mcp`; the script sends no authentication headers and does not load a `.env` file. Free access is rate limited.
+
+Running the script sends its search query, requested URL, objectives, and a random session identifier to Parallel. Use public information when changing the inputs. The script makes requests only when you run it. If you later expose these tools to an agent, that agent may call them during its work according to the host application's tool permissions.
+
+## What to look for
+
+1. **Initialize:** the SDK negotiates the connection and manages the transport lifecycle.
+2. **Discover:** `list_tools()` prints the server's tool names and input schemas, including `web_search` and `web_fetch`.
+3. **Search:** `web_search` receives both an objective and search queries, then returns public web results with source URLs and excerpts.
+4. **Fetch:** `web_fetch` extracts text from a known public documentation page. It does not control a browser or use your signed-in sessions.
+
+The output contains live results, so URLs and excerpts can change. The script prints the text representation of each tool response once, including warnings and any per-URL fetch errors. A fetch can contain successful pages and errors together; inspect both before using the results. An MCP tool error stops the script, and the whole exercise has a 90-second timeout. Connection failures and rate limits also surface as errors; wait before retrying rather than running repeated requests.
+
+Both calls share one randomly generated `session_id` for this exercise. This is separate from the HTTP transport session managed by the SDK.
+
+Try changing the search objective and queries, then fetch a public URL from the search results. Compare the server's advertised schemas with the arguments in the script. Treat returned page text as external data, not as instructions for your agent.
+
+[Back to Lesson 11](../../README.md)

--- a/11-agentic-protocols/code_samples/parallel-search-mcp/README.md
+++ b/11-agentic-protocols/code_samples/parallel-search-mcp/README.md
@@ -4,7 +4,7 @@ This optional Lesson 11 exercise connects to [Parallel Search MCP](https://docs.
 
 ## Run the example
 
-Use Python 3.12 or later with the course's `mcp[cli]` dependency installed. If you have not installed the course dependencies, you can run this exercise in a virtual environment with just the MCP SDK:
+Use Python 3.12 or later. This example uses the MCP SDK 1.x client API; SDK 2.x has a different API. Install the compatible version in a separate virtual environment so the other course examples keep their dependencies:
 
 ```bash
 python -m venv .venv
@@ -12,7 +12,7 @@ python -m venv .venv
 source .venv/bin/activate
 # Windows PowerShell instead:
 # .venv\Scripts\Activate.ps1
-python -m pip install "mcp[cli]"
+python -m pip install "mcp[cli]>=1.28,<2"
 ```
 
 From the repository root, run:

--- a/11-agentic-protocols/code_samples/parallel-search-mcp/client.py
+++ b/11-agentic-protocols/code_samples/parallel-search-mcp/client.py
@@ -9,11 +9,9 @@ from mcp.types import CallToolResult
 
 
 def print_result(name: str, result: CallToolResult) -> None:
-    """Show one result representation, including warnings and per-URL errors."""
+    """Show the complete tool response before raising any tool error."""
     print(f"\n{name}:")
-    for content in result.content:
-        if content.type == "text":
-            print(content.text)
+    print(result.model_dump_json(by_alias=True, exclude_none=True, indent=2))
     if result.isError:
         raise RuntimeError(f"{name} failed; see the tool response above")
 

--- a/11-agentic-protocols/code_samples/parallel-search-mcp/client.py
+++ b/11-agentic-protocols/code_samples/parallel-search-mcp/client.py
@@ -1,0 +1,66 @@
+"""Discover and call a remote MCP server without an LLM or API key."""
+
+import asyncio
+from uuid import uuid4
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.types import CallToolResult
+
+
+def print_result(name: str, result: CallToolResult) -> None:
+    """Show one result representation, including warnings and per-URL errors."""
+    print(f"\n{name}:")
+    for content in result.content:
+        if content.type == "text":
+            print(content.text)
+    if result.isError:
+        raise RuntimeError(f"{name} failed; see the tool response above")
+
+
+async def main() -> None:
+    # One identifier for the related search and fetch, separate from MCP's
+    # transport session, which the SDK manages.
+    session_id = str(uuid4())
+    async with asyncio.timeout(90):
+        async with streamablehttp_client("https://search.parallel.ai/mcp") as (
+            read_stream,
+            write_stream,
+            _,
+        ):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+
+                cursor = None
+                while True:
+                    page = await session.list_tools(cursor=cursor)
+                    for tool in page.tools:
+                        print(f"Tool: {tool.name}\nInput schema: {tool.inputSchema}")
+                    cursor = page.nextCursor
+                    if not cursor:
+                        break
+
+                search = await session.call_tool(
+                    "web_search",
+                    arguments={
+                        "objective": "Find the official Python MCP SDK documentation",
+                        "search_queries": ["MCP Python SDK Streamable HTTP client"],
+                        "session_id": session_id,
+                    },
+                )
+                print_result("web_search", search)
+
+                # Fetch a known public page to keep the exercise reproducible.
+                fetch = await session.call_tool(
+                    "web_fetch",
+                    arguments={
+                        "urls": ["https://github.com/modelcontextprotocol/python-sdk"],
+                        "objective": "Explain how a Python MCP client connects to a server",
+                        "session_id": session_id,
+                    },
+                )
+                print_result("web_fetch", fetch)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Adds an optional Lesson 11 exercise that shows a real remote MCP connection, tool discovery, public web search, and page extraction. The existing notebook simulates MCP-style discovery; this small script lets learners inspect the protocol steps without setting up Azure or a local server.

There isn't a repo-wide default web-search provider to replace, so I compared the options on [Artificial Analysis's Search API leaderboard](https://artificialanalysis.ai/agents/search-api), which lists data through August 31, 2026. A few results make Parallel worth trying:

- **Research quality:** Parallel advanced scored **80.6 F1 on DeepSearchQA**, ahead of Brave (LLM context, 78.1), Exa (auto, 77.8), You.com (highlights, 76.7), Tavily (basic, 74.4), Firecrawl (73.6), Keenable (pro, 70.1), and TinyFish (web, 67.2). Those are each competitor's highest DeepSearchQA scores across its listed configurations.
- **Speed:** Parallel fast had the lowest time per task across all 19 configurations, **19.2 seconds**. For comparison, Perplexity medium took 28.6 seconds, Tavily basic 45.9, TinyFish web 60.1, and Firecrawl 63.0. AA defines this metric as derived model time plus measured search time.
- **Search cost:** Parallel fast used **$8.41 per 1,000 benchmark tasks**, compared with Tavily basic's $126.44, about **93% less**. These figures cover search API spending, not model tokens.

Perplexity medium still leads AA's overall quality index. The numbers above are [API benchmark results from AA's fixed harness](https://artificialanalysis.ai/methodology/search-api), not measurements of this free MCP example. They're a reason to give learners a working Parallel option and let them try it on their own tasks.

The sample uses the existing Python MCP SDK dependency and Parallel’s anonymous Streamable HTTP endpoint. It needs no Parallel account or API key. The README explains which inputs go to Parallel, rate limits, and how to inspect tool errors. Existing notebooks and dependencies are unchanged.

Verified the exact script with MCP SDK 1.28.1 and Python 3.14.6 in an empty environment: both tools were discovered, search returned 10 results, and fetch returned one page with no reported errors or warnings. Python 3.12 syntax, new relative links, the public setup link, and `git diff --check` also passed. No repository build or existing notebook execution was performed.

I work at Parallel, which operates this service.
