### PR TITLE
[Lesson-04] Add an MCP server tool example to the Agent Framework section

### DIFF
--- a/04-tool-use/README.md
+++ b/04-tool-use/README.md
@@ -237,6 +237,33 @@ provider = FoundryChatClient(
 agent = provider.as_agent(name="TimeAgent", instructions="Use available tools to answer questions.", tools=get_current_time)
 response = await agent.run("What time is it?")
 ```
+
+#### Tools from an MCP server
+
+Tools do not have to be functions in your own code. A server that speaks the Model Context Protocol (MCP, covered in [Lesson 11](../11-agentic-protocols/README.md)) publishes its tools together with their schemas, and the framework can load them the same way it serializes a decorated function. `MCPStreamableHTTPTool` connects to such a server over HTTP, reads the tool schemas, and offers them to the model next to any local tools.
+
+The example below uses the web search server hosted by <a href="https://keenable.ai" target="_blank">Keenable</a>. It is free to use without an account or API key (requests are rate limited per IP), so the only credentials you need are the ones for your model. As with any remote tool, the queries the model writes are sent to that server.
+
+```python
+from agent_framework import MCPStreamableHTTPTool
+
+web_search = MCPStreamableHTTPTool(
+    name="Keenable web search",
+    url="https://api.keenable.ai/mcp",
+)
+
+# Connecting loads the server's tool schemas; the agent decides when to call them
+async with web_search:
+    agent = provider.as_agent(
+        name="ResearchAgent",
+        instructions="Use available tools to answer questions.",
+        tools=[web_search],
+    )
+    response = await agent.run("What is new in the latest Python release?")
+    print(response.text)
+```
+
+The server publishes two tools, `search_web_pages` and `fetch_page_content`. When a question needs current information, the model calls `search_web_pages`, gets back titles, URLs and text snippets, and writes its answer from them, the same loop as in the `get_current_time` example above.
   
 ### Microsoft Foundry Agent Service
 


### PR DESCRIPTION
Lesson 04 shows Agent Framework tools as local functions with `@tool`. This adds a short subsection right after that example, "Tools from an MCP server", showing that an agent can also load tools from an MCP server that publishes their schemas, using `MCPStreamableHTTPTool` passed through `tools=[...]` so the model decides when to call them.

The example points at the web search MCP server hosted by [Keenable](https://keenable.ai). It works without an account or API key and is rate limited per IP, so a reader can run it with only the Foundry credentials the lesson already requires. I work at Keenable.

Changes: `04-tool-use/README.md` only, +27 lines. No notebook, translation or lesson 11 changes. Lesson 04 links to lesson 11 for MCP itself.

Checked: `MCPStreamableHTTPTool(name, url)` inside `async with` and `as_agent(tools=[...])` match the current Learn docs for local MCP tools and `agent-framework-core` 1.17.0; the tool object connected to the server, loaded `search_web_pages` and `fetch_page_content`, and a direct `search_web_pages` call returned results. I did not run the agent end to end against Foundry.
