### PR TITLE
Pin mcp[cli] below 2 to match agent-framework-core 1.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ agent-framework-openai~=1.10.0
 a2a-sdk
 
 # Model Context Protocol
-mcp[cli]
+mcp[cli]<2
 
 # OpenAI - Responses API requires >=1.108.1
 openai>=1.108.1


### PR DESCRIPTION
`requirements.txt` pins `agent-framework-core==1.10.0` but leaves `mcp[cli]` unpinned. Today that resolves to `mcp` 2.x, whose `InitializeResult` renamed `protocolVersion` to `protocol_version`, and every `MCPStreamableHTTPTool` / `MCPStdioTool` in core 1.10.0 then fails on connect with:

```
MCP server failed to initialize: 'InitializeResult' object has no attribute 'protocolVersion'
```

`agent-framework-core` declares `mcp<2,>=1.24.0` itself, but only under its `[all]` extra, so the bare pin does not constrain the separate `mcp[cli]` line. Pinning `mcp[cli]<2` matches what the framework requires and makes the MCP samples in lessons 04 and 11 work from a clean `pip install -r requirements.txt`. Verified in a fresh venv: with `mcp` 1.x the tool connects and lists tools; with 2.1.1 it fails as above.

Readers who install through the notebooks' `%pip install agent-framework ...` get the `[all]` extra and are not affected; this only fixes the root requirements file.
